### PR TITLE
add github workflow for tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,33 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  tox:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-22.04]
+    steps:
+    - uses: actions/checkout@v4
+    - run: |
+        sudo apt update
+        sudo apt install python3-btrfsutil tox
+    - run: |
+        sudo tox
+
+  pre-commit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        py: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.py }}
+        cache: pip
+    - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
I've done most of my development on gitlab so far. I have reservations about Github being owned by Microsoft.

Unfortunately gitlab's CI is docker-based. [I can't work out how to mount a loopback btrfs filesystem there](https://forum.gitlab.com/t/how-can-i-mount-a-btrfs-filesystem-on-a-gitlab-hosted-ci-runner/103794), which is required for testing. Github's CI is VM-based, which allows for unrestricted access to mounts and modules, which is apparently required to test btrfs interactions.

This PR is to test whether I will be able to run the full test suite on github instead. If it works, I'll probably migrate my development here.