### PR TITLE
add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly


### PR DESCRIPTION
github actions can be annoying when they suddenly drop support for something. I like dependabot to keep them up-to-date. Updating them is the same amount of work, I just get to do it on an easier schedule