### PR TITLE
remove gitlab tox environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,11 +77,6 @@ order-by-type = false
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.pytest.ini_options]
-markers = [
-  "root",
-]
-
 [tool.mypy]
 mypy_path = "typeshed"
 strict = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,12 +98,6 @@ def download_and_pipe(s3: S3Client, bucket: str) -> DownloadAndPipe:
     return inner
 
 
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    for item in items:
-        if "btrfs_mountpoint" in item.fixturenames:  # type: ignore[attr-defined]
-            item.add_marker("root")
-
-
 def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption("--update-golden", action="store_true")
     parser.addoption("--remove-stale-golden", action="store_true")

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ requires =
     tox>=4.2
 env_list =
     py
-    gitlab
 
 [testenv]
 system_site_packages = true
@@ -16,14 +15,6 @@ commands =
     coverage erase
     coverage run -m pytest {posargs}
     coverage report
-
-[testenv:gitlab]
-system_site_packages = true
-deps =
-    moto[s3]
-    pytest
-commands =
-    pytest -m "not root" {posargs}
 
 [coverage:run]
 plugins = covdefaults


### PR DESCRIPTION
The gitlab tox environment was there just to run the subset of the test suite that worked on gitlab ci. We can remove it.

Especially because the current github workflow invocation actually runs both the full test suite and the gitlab subset. This will speed things up.