### PR TITLE
support python 3.8 for now

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04]
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
     steps:
     - uses: actions/checkout@v4
     - run: |
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        py: ["3.9", "3.10", "3.11", "3.12"]
+        py: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,10 @@ description = "Snapshot btrfs volumes and back them up to s3"
 authors = [
   { name = "Steven Brudenell", email = "steven.brudenell@gmail.com" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -24,6 +25,7 @@ dynamic = [
 ]
 dependencies = [
   "arrow>=1",
+  "backports-zoneinfo; python_version<'3.9'",
   "boto3[crt]",
   "rich",
   "typing-extensions>=4.4",
@@ -94,6 +96,18 @@ legacy_tox_ini = """
       coverage
       moto[s3]
       pytest
+  # btrfs2s3 requires --system-site-packages. This means we can generally end
+  # up pulling in weird package versions in configurations that don't exist any
+  # other way. In particular on Ubuntu 20.04, we can end up with
+  # system-provided python3-openssl (version 19.0.0), but will end up
+  # installing a newer version of cryptography. The old pyopenssl breaks with
+  # the newer cryptography. This would resolve itself if pyopenssl had a proper
+  # dependency like "cryptography>=X,<Y", but this was only introduced in newer
+  # pyopenssl.
+      pyopenssl>=22.1
+  # similarly: we pull markupsafe>=2, which breaks jinja2<3, but moto depends
+  # only on jinja2>=2.10.1
+      jinja2>=3
   commands =
       coverage erase
       coverage run -m pytest {posargs}

--- a/src/btrfs2s3/_internal/arrowutil.py
+++ b/src/btrfs2s3/_internal/arrowutil.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from typing import Iterable
 
     from arrow import Arrow
 

--- a/src/btrfs2s3/action.py
+++ b/src/btrfs2s3/action.py
@@ -17,9 +17,9 @@ from btrfs2s3.thunk import Thunk
 from btrfs2s3.thunk import ThunkArg
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-    from collections.abc import Sequence
     from pathlib import Path
+    from typing import Iterator
+    from typing import Sequence
 
     from mypy_boto3_s3.client import S3Client
 

--- a/src/btrfs2s3/assessor.py
+++ b/src/btrfs2s3/assessor.py
@@ -22,8 +22,8 @@ from btrfs2s3.thunk import Thunk
 from btrfs2s3.thunk import ThunkArg
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
     from pathlib import Path
+    from typing import Sequence
 
     from mypy_boto3_s3.client import S3Client
 
@@ -277,7 +277,7 @@ class _Assessor:
             raise RuntimeError(msg)
         for name, info in btrfsutil.SubvolumeIterator(search_base, info=True):
             path = search_base / name
-            if not path.is_relative_to(self.snapshot_dir):
+            if self.snapshot_dir not in path.parents:
                 continue
             if info.parent_uuid not in self._assessment.sources:
                 continue

--- a/src/btrfs2s3/backups.py
+++ b/src/btrfs2s3/backups.py
@@ -14,8 +14,8 @@ from arrow import Arrow
 from typing_extensions import Self
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
     from datetime import tzinfo
+    from typing import Sequence
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/btrfs2s3/commands/run.py
+++ b/src/btrfs2s3/commands/run.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from collections import defaultdict
 from pathlib import Path
 import shlex
+import sys
 from typing import TYPE_CHECKING
-import zoneinfo
 
 import arrow
 from boto3.session import Session
@@ -35,12 +35,18 @@ from btrfs2s3.resolver import KeepMeta
 from btrfs2s3.resolver import Reasons
 from btrfs2s3.thunk import TBD
 
+if sys.version_info >= (3, 9):  # pragma: >=3.9 cover
+    from zoneinfo import ZoneInfo
+else:  # pragma: <3.9 cover
+    from backports.zoneinfo import ZoneInfo
+
+
 if TYPE_CHECKING:
     import argparse
-    from collections.abc import Iterable
-    from collections.abc import Sequence
     from datetime import tzinfo
+    from typing import Iterable
     from typing import Literal
+    from typing import Sequence
 
     from typing_extensions import TypeAlias
 
@@ -344,7 +350,7 @@ def add_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--source", action="append", type=Path, required=True)
     parser.add_argument("--snapshot-dir", type=Path, required=True)
     parser.add_argument("--bucket", required=True)
-    parser.add_argument("--timezone", type=zoneinfo.ZoneInfo, required=True)
+    parser.add_argument("--timezone", type=ZoneInfo, required=True)
     parser.add_argument("--preserve", type=Params.parse, required=True)
     parser.add_argument("--pipe-through", action="append", type=shlex.split, default=[])
 

--- a/src/btrfs2s3/main.py
+++ b/src/btrfs2s3/main.py
@@ -13,7 +13,7 @@ from btrfs2s3.commands import run
 from btrfs2s3.console import CONSOLE
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from typing import Sequence
 
     from rich.console import Console
 

--- a/src/btrfs2s3/preservation.py
+++ b/src/btrfs2s3/preservation.py
@@ -50,6 +50,7 @@ from datetime import tzinfo
 import re
 from typing import Generic
 from typing import Literal
+from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import TypeVar
 
@@ -62,10 +63,10 @@ from btrfs2s3._internal.arrowutil import convert_span
 from btrfs2s3._internal.arrowutil import iter_time_spans
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-    from collections.abc import Mapping
+    from typing import Iterator
+    from typing import Mapping
 
-TS: TypeAlias = tuple[float, float]
+TS: TypeAlias = Tuple[float, float]
 """An alias for tuple[float, float] which is used as a time span type.
 
 This is just provided because it's frequently used, and shorter than

--- a/src/btrfs2s3/resolver.py
+++ b/src/btrfs2s3/resolver.py
@@ -22,8 +22,8 @@ from btrfs2s3._internal.util import backup_of_snapshot
 from btrfs2s3.backups import BackupInfo
 
 if TYPE_CHECKING:
-    from collections.abc import Collection
-    from collections.abc import Iterator
+    from typing import Collection
+    from typing import Iterator
 
     from btrfs2s3.preservation import Policy
     from btrfs2s3.preservation import TS
@@ -182,19 +182,15 @@ class _Resolver:
 
     @contextlib.contextmanager
     def _with_time_span(self, time_span: TS) -> Iterator[None]:
-        with (
-            self._keep_snapshots.with_time_span(time_span),
-            self._keep_backups.with_time_span(time_span),
-        ):
-            yield
+        with self._keep_snapshots.with_time_span(time_span):  # noqa: SIM117
+            with self._keep_backups.with_time_span(time_span):
+                yield
 
     @contextlib.contextmanager
     def _with_reasons(self, reasons: Reasons) -> Iterator[None]:
-        with (
-            self._keep_snapshots.with_reasons(reasons),
-            self._keep_backups.with_reasons(reasons),
-        ):
-            yield
+        with self._keep_snapshots.with_reasons(reasons):  # noqa: SIM117
+            with self._keep_backups.with_reasons(reasons):
+                yield
 
     def get_result(self) -> Result:
         return Result(

--- a/src/btrfs2s3/s3.py
+++ b/src/btrfs2s3/s3.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from btrfs2s3.backups import BackupInfo
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from typing import Iterator
 
     from mypy_boto3_s3.client import S3Client
     from mypy_boto3_s3.type_defs import ListObjectsV2RequestRequestTypeDef

--- a/tests/action/action_test.py
+++ b/tests/action/action_test.py
@@ -33,7 +33,7 @@ def test_create_and_rename(btrfs_mountpoint: Path, s3: S3Client, bucket: str) ->
 
     initial_path = btrfs_mountpoint / "snapshot"
 
-    @functools.cache
+    @functools.lru_cache
     def get_info() -> SubvolumeInfo:
         return btrfsutil.subvolume_info(initial_path)
 
@@ -68,7 +68,7 @@ def test_create_rename_backup(
 
     initial_path = btrfs_mountpoint / "snapshot2"
 
-    @functools.cache
+    @functools.lru_cache
     def get_info() -> SubvolumeInfo:
         return btrfsutil.subvolume_info(initial_path)
 

--- a/tests/assessor/assess_test.py
+++ b/tests/assessor/assess_test.py
@@ -79,7 +79,7 @@ def test_create_and_backup_new_snapshot(
 
     (create_snapshot_intent,) = list(actions.iter_create_snapshot_intents())
     assert create_snapshot_intent.source.peek() == source
-    assert create_snapshot_intent.path().is_relative_to(snapshot_dir)
+    assert snapshot_dir in create_snapshot_intent.path().parents
     assert create_snapshot_intent.path().name.startswith(source.name)
     (rename_snapshot_intent,) = list(actions.iter_rename_snapshot_intents())
     assert rename_snapshot_intent.source.peek() == create_snapshot_intent.path.peek()
@@ -318,7 +318,7 @@ def test_delete_only_snapshot_because_proposed_would_be_newer(
 
     (create_snapshot_intent,) = list(actions.iter_create_snapshot_intents())
     assert create_snapshot_intent.source.peek() == source
-    assert create_snapshot_intent.path().is_relative_to(snapshot_dir)
+    assert snapshot_dir in create_snapshot_intent.path().parents
     assert create_snapshot_intent.path().name.startswith(source.name)
     (rename_snapshot_intent,) = list(actions.iter_rename_snapshot_intents())
     assert rename_snapshot_intent.source.peek() == create_snapshot_intent.path.peek()

--- a/tests/backups/path_test.py
+++ b/tests/backups/path_test.py
@@ -1,10 +1,15 @@
-from collections.abc import Sequence
+from __future__ import annotations
+
 import itertools
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 import arrow
 from btrfs2s3.backups import BackupInfo
 import pytest
+
+if TYPE_CHECKING:
+    from typing import Sequence
 
 
 def test_get_path_suffixes_with_real_timezone() -> None:

--- a/tests/commands/run/describe_time_span_test.py
+++ b/tests/commands/run/describe_time_span_test.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
-from zoneinfo import ZoneInfo
+import sys
 
 import arrow
 from btrfs2s3.commands.run import describe_time_span
 import pytest
 from rich.text import Span
+
+if sys.version_info >= (3, 9):  # pragma: >=3.9 cover
+    from zoneinfo import ZoneInfo
+else:  # pragma: <3.9 cover
+    from backports.zoneinfo import ZoneInfo
 
 
 @pytest.mark.parametrize(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,9 +19,9 @@ import pytest
 from rich.console import Console
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-    from collections.abc import Sequence
     from typing import IO
+    from typing import Iterator
+    from typing import Sequence
 
     from mypy_boto3_s3.client import S3Client
 

--- a/tests/preservation/policy_test.py
+++ b/tests/preservation/policy_test.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from random import uniform
+import sys
 import time
 from typing import cast
-from zoneinfo import ZoneInfo
 
 import arrow
 from btrfs2s3._internal.arrowutil import convert_span
@@ -12,6 +12,11 @@ from btrfs2s3.preservation import Policy
 from btrfs2s3.preservation import Timeframe
 from btrfs2s3.preservation import TIMEFRAMES
 import pytest
+
+if sys.version_info >= (3, 9):  # pragma: >=3.9 cover
+    from zoneinfo import ZoneInfo
+else:  # pragma: <3.9 cover
+    from backports.zoneinfo import ZoneInfo
 
 
 def _random_timestamp() -> float:

--- a/tests/resolver/index_test.py
+++ b/tests/resolver/index_test.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-import functools
-import random
+from uuid import uuid4
 
 from btrfs2s3._internal.util import mksubvol
 from btrfs2s3.backups import BackupInfo
 from btrfs2s3.preservation import Policy
 from btrfs2s3.resolver import _Index
-
-mkuuid = functools.partial(random.randbytes, 16)
 
 
 def test_get_nominal_none() -> None:
@@ -36,7 +33,11 @@ def test_get_nominal_snapshot_one_of_many() -> None:
 
 def test_get_nominal_backup_one() -> None:
     backup = BackupInfo(
-        uuid=mkuuid(), parent_uuid=mkuuid(), send_parent_uuid=None, ctime=0, ctransid=0
+        uuid=uuid4().bytes,
+        parent_uuid=uuid4().bytes,
+        send_parent_uuid=None,
+        ctime=0,
+        ctransid=0,
     )
     index = _Index(policy=Policy.all(), items=(backup,))
     for timespan in Policy.all().iter_time_spans(backup.ctime):
@@ -46,10 +47,14 @@ def test_get_nominal_backup_one() -> None:
 
 def test_get_nominal_backup_one_of_many() -> None:
     backup1 = BackupInfo(
-        uuid=mkuuid(), parent_uuid=mkuuid(), send_parent_uuid=None, ctime=0, ctransid=0
+        uuid=uuid4().bytes,
+        parent_uuid=uuid4().bytes,
+        send_parent_uuid=None,
+        ctime=0,
+        ctransid=0,
     )
     backup2 = BackupInfo(
-        uuid=mkuuid(),
+        uuid=uuid4().bytes,
         parent_uuid=backup1.parent_uuid,
         send_parent_uuid=None,
         ctime=0,
@@ -63,12 +68,12 @@ def test_get_nominal_backup_one_of_many() -> None:
 
 def test_get_none() -> None:
     index = _Index(policy=Policy(), items=())
-    got = index.get(mkuuid())
+    got = index.get(uuid4().bytes)
     assert got is None
 
 
 def test_get_snapshot() -> None:
-    snapshot = mksubvol(uuid=mkuuid())
+    snapshot = mksubvol(uuid=uuid4().bytes)
     index = _Index(policy=Policy(), items=(snapshot,))
     got = index.get(snapshot.uuid)
     assert got == snapshot
@@ -76,7 +81,11 @@ def test_get_snapshot() -> None:
 
 def test_get_backup() -> None:
     backup = BackupInfo(
-        uuid=mkuuid(), parent_uuid=mkuuid(), send_parent_uuid=None, ctime=0, ctransid=0
+        uuid=uuid4().bytes,
+        parent_uuid=uuid4().bytes,
+        send_parent_uuid=None,
+        ctime=0,
+        ctransid=0,
     )
     index = _Index(policy=Policy(), items=(backup,))
     got = index.get(backup.uuid)
@@ -90,8 +99,8 @@ def test_get_most_recent_none() -> None:
 
 
 def test_get_most_recent_snapshot() -> None:
-    snapshot1 = mksubvol(uuid=mkuuid(), ctransid=1)
-    snapshot2 = mksubvol(uuid=mkuuid(), ctransid=2)
+    snapshot1 = mksubvol(uuid=uuid4().bytes, ctransid=1)
+    snapshot2 = mksubvol(uuid=uuid4().bytes, ctransid=2)
     index = _Index(policy=Policy(), items=(snapshot1, snapshot2))
     got = index.get_most_recent()
     assert got == snapshot2
@@ -104,7 +113,7 @@ def test_get_all_time_spans_empty() -> None:
 
 
 def test_get_all_time_spans() -> None:
-    snapshot = mksubvol(uuid=mkuuid(), ctime=2000000000.0)
+    snapshot = mksubvol(uuid=uuid4().bytes, ctime=2000000000.0)
     index = _Index(policy=Policy.all(), items=(snapshot,))
     got = index.get_all_time_spans()
     assert got == set(Policy.all().iter_time_spans(snapshot.ctime))

--- a/tests/resolver/keep_backup_of_snapshot_test.py
+++ b/tests/resolver/keep_backup_of_snapshot_test.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import functools
-import random
 from typing import Protocol
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import arrow
 from btrfs2s3._internal.util import backup_of_snapshot
@@ -19,12 +18,10 @@ import pytest
 if TYPE_CHECKING:
     from btrfsutil import SubvolumeInfo
 
-mkuuid = functools.partial(random.randbytes, 16)
-
 
 @pytest.fixture()
 def parent_uuid() -> bytes:
-    return mkuuid()
+    return uuid4().bytes
 
 
 class MkSnap(Protocol):
@@ -36,7 +33,7 @@ def mksnap(parent_uuid: bytes) -> MkSnap:
     def inner(*, t: str | None = None, i: int = 0) -> SubvolumeInfo:
         a = arrow.get() if t is None else arrow.get(t)
         return mksubvol(
-            uuid=mkuuid(), parent_uuid=parent_uuid, ctime=a.timestamp(), ctransid=i
+            uuid=uuid4().bytes, parent_uuid=parent_uuid, ctime=a.timestamp(), ctransid=i
         )
 
     return inner

--- a/tests/resolver/keep_most_recent_snapshot_test.py
+++ b/tests/resolver/keep_most_recent_snapshot_test.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import functools
-import random
 from typing import Protocol
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import arrow
 from btrfs2s3._internal.util import backup_of_snapshot
@@ -21,12 +20,10 @@ import pytest
 if TYPE_CHECKING:
     from btrfsutil import SubvolumeInfo
 
-mkuuid = functools.partial(random.randbytes, 16)
-
 
 @pytest.fixture()
 def parent_uuid() -> bytes:
-    return mkuuid()
+    return uuid4().bytes
 
 
 class MkSnap(Protocol):
@@ -38,7 +35,7 @@ def mksnap(parent_uuid: bytes) -> MkSnap:
     def inner(*, t: str | None = None, i: int = 0) -> SubvolumeInfo:
         a = arrow.get() if t is None else arrow.get(t)
         return mksubvol(
-            uuid=mkuuid(), parent_uuid=parent_uuid, ctime=a.timestamp(), ctransid=i
+            uuid=uuid4().bytes, parent_uuid=parent_uuid, ctime=a.timestamp(), ctransid=i
         )
 
     return inner

--- a/tests/resolver/keep_send_ancestors_of_backups_test.py
+++ b/tests/resolver/keep_send_ancestors_of_backups_test.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import functools
-import random
 from typing import Protocol
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import arrow
 from btrfs2s3._internal.util import backup_of_snapshot
@@ -20,12 +19,10 @@ import pytest
 if TYPE_CHECKING:
     from btrfsutil import SubvolumeInfo
 
-mkuuid = functools.partial(random.randbytes, 16)
-
 
 @pytest.fixture()
 def parent_uuid() -> bytes:
-    return mkuuid()
+    return uuid4().bytes
 
 
 class MkSnap(Protocol):
@@ -37,7 +34,7 @@ def mksnap(parent_uuid: bytes) -> MkSnap:
     def inner(*, t: str | None = None, i: int = 0) -> SubvolumeInfo:
         a = arrow.get() if t is None else arrow.get(t)
         return mksubvol(
-            uuid=mkuuid(), parent_uuid=parent_uuid, ctime=a.timestamp(), ctransid=i
+            uuid=uuid4().bytes, parent_uuid=parent_uuid, ctime=a.timestamp(), ctransid=i
         )
 
     return inner

--- a/tests/resolver/keep_snapshot_and_backup_for_time_span_test.py
+++ b/tests/resolver/keep_snapshot_and_backup_for_time_span_test.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import functools
-import random
 from typing import Protocol
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import arrow
 from btrfs2s3._internal.util import backup_of_snapshot
@@ -22,12 +21,10 @@ import pytest
 if TYPE_CHECKING:
     from btrfsutil import SubvolumeInfo
 
-mkuuid = functools.partial(random.randbytes, 16)
-
 
 @pytest.fixture()
 def parent_uuid() -> bytes:
-    return mkuuid()
+    return uuid4().bytes
 
 
 class MkSnap(Protocol):
@@ -39,7 +36,7 @@ def mksnap(parent_uuid: bytes) -> MkSnap:
     def inner(*, t: str | None = None, i: int = 0) -> SubvolumeInfo:
         a = arrow.get() if t is None else arrow.get(t)
         return mksubvol(
-            uuid=mkuuid(), parent_uuid=parent_uuid, ctime=a.timestamp(), ctransid=i
+            uuid=uuid4().bytes, parent_uuid=parent_uuid, ctime=a.timestamp(), ctransid=i
         )
 
     return inner

--- a/tests/resolver/marker_test.py
+++ b/tests/resolver/marker_test.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import functools
-import random
-
 from btrfs2s3._internal.util import mksubvol
 from btrfs2s3.resolver import _MarkedItem
 from btrfs2s3.resolver import _Marker
@@ -10,8 +7,6 @@ from btrfs2s3.resolver import Flags
 from btrfs2s3.resolver import KeepMeta
 from btrfs2s3.resolver import Reasons
 from btrfsutil import SubvolumeInfo
-
-mkuuid = functools.partial(random.randbytes, 16)
 
 
 def test_empty() -> None:

--- a/tests/resolver/resolve_test.py
+++ b/tests/resolver/resolve_test.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import functools
-import random
 from typing import Protocol
 from typing import TYPE_CHECKING
 
@@ -22,12 +20,12 @@ import pytest
 if TYPE_CHECKING:
     from btrfsutil import SubvolumeInfo
 
-mkuuid = functools.partial(random.randbytes, 16)
+from uuid import uuid4
 
 
 @pytest.fixture()
 def parent_uuid() -> bytes:
-    return mkuuid()
+    return uuid4().bytes
 
 
 class MkSnap(Protocol):
@@ -39,7 +37,7 @@ def mksnap(parent_uuid: bytes) -> MkSnap:
     def inner(*, t: str | None = None, i: int = 0) -> SubvolumeInfo:
         a = arrow.get() if t is None else arrow.get(t)
         return mksubvol(
-            uuid=mkuuid(), parent_uuid=parent_uuid, ctime=a.timestamp(), ctransid=i
+            uuid=uuid4().bytes, parent_uuid=parent_uuid, ctime=a.timestamp(), ctransid=i
         )
 
     return inner


### PR DESCRIPTION
my main motivation for this is to support ubuntu 20.04, which will still be around for several years, especially as a github test env. they seem to have a longer support lifetime for python 3.8 than python itself does.