### PR TITLE
use btrfs send -q instead of btrfs -q send

### DIFF
--- a/src/btrfs2s3/action.py
+++ b/src/btrfs2s3/action.py
@@ -103,7 +103,7 @@ def create_backup(  # noqa: PLR0913
         snapshot,
         f"delta from {send_parent}" if send_parent else "full",
     )
-    send_args: list[str | Path] = ["btrfs", "-q", "send"]
+    send_args: list[str | Path] = ["btrfs", "send", "-q"]
     if send_parent is not None:
         send_args += ["-p", send_parent]
     send_args += [snapshot]


### PR DESCRIPTION
-q did not appear as a global option in older btrfs-progs (at least 5.4.1 which appears on ubuntu-20.04)