### PR TITLE
refactor(piper): add a command filter context manager

### DIFF
--- a/src/btrfs2s3/_internal/piper.py
+++ b/src/btrfs2s3/_internal/piper.py
@@ -1,0 +1,88 @@
+# btrfs2s3 - maintains a tree of differential backups in object storage.
+#
+# Copyright (C) 2025 Steven Brudenell and other contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from contextlib import contextmanager
+from contextlib import ExitStack
+import os
+from subprocess import CalledProcessError
+from subprocess import PIPE
+from subprocess import Popen
+from typing import AnyStr
+from typing import NamedTuple
+from typing import TYPE_CHECKING
+from typing import Union
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from typing import IO
+
+    from typing_extensions import TypeAlias
+
+_StrOrBytesPath = Union[os.PathLike[str], os.PathLike[bytes], str, bytes]
+_CMD: TypeAlias = Union[_StrOrBytesPath, Sequence[_StrOrBytesPath]]
+
+
+class Pipe(NamedTuple):
+    r: IO[bytes]
+    w: IO[bytes]
+
+
+@contextmanager
+def _pipe() -> Iterator[Pipe]:
+    r_fd, w_fd = os.pipe()
+    with (
+        open(r_fd, mode="rb") as r,  # noqa: PTH123
+        open(w_fd, mode="wb") as w,  # noqa: PTH123
+    ):
+        yield Pipe(r=r, w=w)
+
+
+@contextmanager
+def _pipefail(process: Popen[AnyStr]) -> Iterator[Popen[AnyStr]]:
+    # We could do try/finally here to create a big exception stack on an error,
+    # but there's probably not a need
+    with process:
+        yield process
+    retcode = process.wait()
+    if retcode != 0:
+        raise CalledProcessError(retcode, process.args)
+
+
+@contextmanager
+def filter_pipe(commands: Sequence[_CMD]) -> Iterator[Pipe]:
+    pipe: Pipe | None = None
+    with ExitStack() as stack:
+        for args in commands:
+            process = Popen(args, stdin=pipe.r if pipe else PIPE, stdout=PIPE)
+            stack.enter_context(_pipefail(process))
+            # NB: Popen.stdout is only non-None when Popen(stdout=PIPE) is passed
+            # https://github.com/python/typeshed/issues/3831
+            assert process.stdout is not None
+            if pipe:
+                # https://docs.python.org/3/library/subprocess.html#replacing-shell-pipeline
+                pipe.r.close()
+                pipe = Pipe(r=process.stdout, w=pipe.w)
+            else:
+                assert process.stdin is not None
+                pipe = Pipe(r=process.stdout, w=process.stdin)
+        if pipe:
+            yield pipe
+        else:
+            yield stack.enter_context(_pipe())

--- a/tests/piper/__init__.py
+++ b/tests/piper/__init__.py
@@ -1,0 +1,16 @@
+# btrfs2s3 - maintains a tree of differential backups in object storage.
+#
+# Copyright (C) 2025 Steven Brudenell and other contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/tests/piper/filter_pipe_test.py
+++ b/tests/piper/filter_pipe_test.py
@@ -1,0 +1,63 @@
+# btrfs2s3 - maintains a tree of differential backups in object storage.
+#
+# Copyright (C) 2025 Steven Brudenell and other contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from subprocess import CalledProcessError
+from typing import cast
+from typing import TYPE_CHECKING
+
+from btrfs2s3._internal.piper import filter_pipe
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import IO
+
+
+def write_then_close(w: IO[bytes], data: bytes) -> None:
+    w.write(data)
+    w.close()
+
+
+def feed_and_check(
+    r: IO[bytes], w: IO[bytes], send_data: bytes, expect_data: bytes
+) -> None:
+    with ThreadPoolExecutor() as executor:
+        executor.submit(write_then_close, w, send_data)
+        got_data = executor.submit(r.read).result()
+    assert got_data == expect_data
+
+
+@pytest.mark.parametrize("length", [0, 1, 2, 3])
+def test_noop(length: int) -> None:
+    with filter_pipe([["cat"]] * length) as (r, w):
+        feed_and_check(r, w, b"hello", b"hello")
+
+
+@pytest.fixture(params=[(length, i) for length in range(1, 4) for i in range(length)])
+def pipeline_that_fails(request: pytest.FixtureRequest) -> Sequence[Sequence[str]]:
+    length, fail_position = cast(tuple[int, int], request.param)
+    cmds = [["cat"]] * length
+    cmds[fail_position] = ["sh", "-c", "exit 1"]
+    return cmds
+
+
+def test_pipefail_raises_error(pipeline_that_fails: Sequence[Sequence[str]]) -> None:
+    with pytest.raises(CalledProcessError), filter_pipe(pipeline_that_fails) as (r, w):
+        w.close()


### PR DESCRIPTION
this isolates the command filter pipeline logic and provides specific tests for "pipefail" scenarios.