### PR TITLE
refactor(resolver): make resolver generic

### DIFF
--- a/tests/resolver/keep_most_recent_snapshot_test.py
+++ b/tests/resolver/keep_most_recent_snapshot_test.py
@@ -25,9 +25,8 @@ import arrow
 from btrfs2s3._internal.preservation import Policy
 from btrfs2s3._internal.resolver import _Resolver
 from btrfs2s3._internal.resolver import Flags
-from btrfs2s3._internal.resolver import KeepBackup
+from btrfs2s3._internal.resolver import Item
 from btrfs2s3._internal.resolver import KeepMeta
-from btrfs2s3._internal.resolver import KeepSnapshot
 from btrfs2s3._internal.resolver import Reasons
 from btrfs2s3._internal.resolver import Result
 from btrfs2s3._internal.util import backup_of_snapshot
@@ -59,7 +58,9 @@ def mksnap(parent_uuid: bytes) -> MkSnap:
 
 
 def test_noop() -> None:
-    resolver = _Resolver(snapshots=(), backups=(), policy=Policy())
+    resolver = _Resolver(
+        snapshots=(), backups=(), policy=Policy(), mk_backup=backup_of_snapshot
+    )
 
     resolver.keep_most_recent_snapshot()
 
@@ -68,17 +69,19 @@ def test_noop() -> None:
 
 def test_one_snapshot(mksnap: MkSnap) -> None:
     snapshot = mksnap()
-    resolver = _Resolver(snapshots=(snapshot,), backups=(), policy=Policy())
+    resolver = _Resolver(
+        snapshots=(snapshot,), backups=(), policy=Policy(), mk_backup=backup_of_snapshot
+    )
 
     resolver.keep_most_recent_snapshot()
 
     expected_backup = backup_of_snapshot(snapshot, send_parent=None)
     assert resolver.get_result() == Result(
         keep_snapshots={
-            snapshot.uuid: KeepSnapshot(snapshot, KeepMeta(reasons=Reasons.MostRecent))
+            snapshot.uuid: Item(snapshot, KeepMeta(reasons=Reasons.MostRecent))
         },
         keep_backups={
-            expected_backup.uuid: KeepBackup(
+            expected_backup.uuid: Item(
                 expected_backup, KeepMeta(reasons=Reasons.MostRecent, flags=Flags.New)
             )
         },
@@ -90,7 +93,10 @@ def test_multiple_snapshots_keep_most_recent(mksnap: MkSnap) -> None:
     snapshot2 = mksnap(i=2)
     backup1 = backup_of_snapshot(snapshot1, send_parent=None)
     resolver = _Resolver(
-        snapshots=(snapshot1, snapshot2), backups=(backup1,), policy=Policy.all()
+        snapshots=(snapshot1, snapshot2),
+        backups=(backup1,),
+        policy=Policy.all(),
+        mk_backup=backup_of_snapshot,
     )
 
     resolver.keep_most_recent_snapshot()
@@ -98,12 +104,10 @@ def test_multiple_snapshots_keep_most_recent(mksnap: MkSnap) -> None:
     expected_backup = backup_of_snapshot(snapshot2, send_parent=snapshot1)
     assert resolver.get_result() == Result(
         keep_snapshots={
-            snapshot2.uuid: KeepSnapshot(
-                snapshot2, KeepMeta(reasons=Reasons.MostRecent)
-            )
+            snapshot2.uuid: Item(snapshot2, KeepMeta(reasons=Reasons.MostRecent))
         },
         keep_backups={
-            expected_backup.uuid: KeepBackup(
+            expected_backup.uuid: Item(
                 expected_backup, KeepMeta(reasons=Reasons.MostRecent, flags=Flags.New)
             )
         },

--- a/tests/resolver/marker_test.py
+++ b/tests/resolver/marker_test.py
@@ -17,13 +17,17 @@
 
 from __future__ import annotations
 
-from btrfs2s3._internal.resolver import _MarkedItem
+from typing import TYPE_CHECKING
+
 from btrfs2s3._internal.resolver import _Marker
 from btrfs2s3._internal.resolver import Flags
+from btrfs2s3._internal.resolver import Item
 from btrfs2s3._internal.resolver import KeepMeta
 from btrfs2s3._internal.resolver import Reasons
 from btrfs2s3._internal.util import mksubvol
-from btrfsutil import SubvolumeInfo
+
+if TYPE_CHECKING:
+    from btrfsutil import SubvolumeInfo
 
 
 def test_empty() -> None:
@@ -37,9 +41,7 @@ def test_keep_reason() -> None:
     with marker.with_reasons(Reasons.Preserved):
         marker.mark(snapshot)
     assert marker.get_result() == {
-        snapshot.uuid: _MarkedItem(
-            item=snapshot, meta=KeepMeta(reasons=Reasons.Preserved)
-        )
+        snapshot.uuid: Item(item=snapshot, meta=KeepMeta(reasons=Reasons.Preserved))
     }
 
 
@@ -50,7 +52,7 @@ def test_keep_reason_and_time_span() -> None:
     with marker.with_reasons(Reasons.Preserved), marker.with_time_span(time_span):
         marker.mark(snapshot)
     assert marker.get_result() == {
-        snapshot.uuid: _MarkedItem(
+        snapshot.uuid: Item(
             item=snapshot,
             meta=KeepMeta(reasons=Reasons.Preserved, time_spans={time_span}),
         )
@@ -64,7 +66,7 @@ def test_keep_reason_flag_and_time_span() -> None:
     with marker.with_reasons(Reasons.Preserved), marker.with_time_span(time_span):
         marker.mark(snapshot, flags=Flags.New)
     assert marker.get_result() == {
-        snapshot.uuid: _MarkedItem(
+        snapshot.uuid: Item(
             item=snapshot,
             meta=KeepMeta(
                 reasons=Reasons.Preserved, flags=Flags.New, time_spans={time_span}
@@ -81,7 +83,7 @@ def test_keep_for_multiple_reasons() -> None:
         with marker.with_reasons(Reasons.MostRecent):
             marker.mark(snapshot)
     assert marker.get_result() == {
-        snapshot.uuid: _MarkedItem(
+        snapshot.uuid: Item(
             item=snapshot, meta=KeepMeta(reasons=Reasons.Preserved | Reasons.MostRecent)
         )
     }
@@ -95,7 +97,7 @@ def test_keep_with_reason_context() -> None:
     with marker.with_reasons(Reasons.MostRecent):
         marker.mark(snapshot)
     assert marker.get_result() == {
-        snapshot.uuid: _MarkedItem(
+        snapshot.uuid: Item(
             item=snapshot, meta=KeepMeta(reasons=Reasons.Preserved | Reasons.MostRecent)
         )
     }
@@ -108,7 +110,7 @@ def test_keep_with_reason_and_flags() -> None:
         marker.mark(snapshot)
         marker.mark(snapshot, flags=Flags.ReplacingNewer)
     assert marker.get_result() == {
-        snapshot.uuid: _MarkedItem(
+        snapshot.uuid: Item(
             item=snapshot,
             meta=KeepMeta(reasons=Reasons.Preserved, flags=Flags.ReplacingNewer),
         )
@@ -122,7 +124,7 @@ def test_keep_with_time_span_context() -> None:
     with marker.with_reasons(Reasons.Preserved), marker.with_time_span(time_span):
         marker.mark(snapshot)
     assert marker.get_result() == {
-        snapshot.uuid: _MarkedItem[SubvolumeInfo](
+        snapshot.uuid: Item(
             item=snapshot,
             meta=KeepMeta(reasons=Reasons.Preserved, time_spans={time_span}),
         )


### PR DESCRIPTION
this makes resolver generic over its argument types, and not depend directly on SubvolumeInfo/BackupInfo.

the goal is to support the planner refactor, allowing both implementations to exist at the same time.

this requires any call to resolve() to supply a function to convert a snapshot object to a backup object. I experimented with making resolve() receive and/or return data in hermetic tuples, but this requires more conversion code for all callers than this option.