### PR TITLE
refactor(planner): add an update planner

### DIFF
--- a/src/btrfs2s3/_internal/planner.py
+++ b/src/btrfs2s3/_internal/planner.py
@@ -1,0 +1,653 @@
+# btrfs2s3 - maintains a tree of differential backups in object storage.
+#
+# Copyright (C) 2025 Steven Brudenell and other contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
+import logging
+import os
+from typing import NamedTuple
+from typing import Protocol
+from typing import TYPE_CHECKING
+
+import arrow
+
+from btrfs2s3._internal.backups import BackupInfo
+from btrfs2s3._internal.btrfsioctl import create_snap
+from btrfs2s3._internal.btrfsioctl import destroy_snap
+from btrfs2s3._internal.btrfsioctl import FIRST_FREE_OBJECTID
+from btrfs2s3._internal.btrfsioctl import opendir
+from btrfs2s3._internal.btrfsioctl import send
+from btrfs2s3._internal.btrfsioctl import subvol_info
+from btrfs2s3._internal.btrfsioctl import SubvolFlag
+from btrfs2s3._internal.btrfsioctl import SubvolInfo
+from btrfs2s3._internal.resolver import Flags
+from btrfs2s3._internal.resolver import KeepMeta
+from btrfs2s3._internal.resolver import resolve
+from btrfs2s3._internal.s3 import iter_backups
+from btrfs2s3._internal.stream_uploader import upload_non_seekable_stream_via_tempfile
+from btrfs2s3._internal.util import backup_of_snapshot
+from btrfs2s3._internal.util import TZINFO
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+    from collections.abc import Iterator
+    from collections.abc import Mapping
+    from contextlib import AbstractContextManager
+    from pathlib import Path
+    from typing import IO
+
+    from mypy_boto3_s3.client import S3Client
+    from mypy_boto3_s3.type_defs import ObjectTypeDef
+    from typing_extensions import Self
+
+    from btrfs2s3._internal.preservation import Policy
+
+_LOG = logging.getLogger(__name__)
+
+
+def _check_is_subvol(path: Path, fd: int) -> None:
+    if not _is_subvol(fd):
+        msg = f"{path} is not a subvolume boundary"
+        raise ValueError(msg)
+
+
+class Source:
+    @classmethod
+    def create(cls, path: Path) -> Self:
+        fd = os.open(path, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            _check_is_subvol(path, fd)
+            info = subvol_info(fd)
+            return cls(path=path, fd=fd, info=info)
+        except Exception:
+            os.close(fd)
+            raise
+
+    def __init__(self, *, path: Path, info: SubvolInfo, fd: int) -> None:
+        self._path = path
+        self._info = info
+        self._fd = fd
+
+    @property
+    def fd(self) -> int:
+        return self._fd
+
+    @property
+    def info(self) -> SubvolInfo:
+        return self._info
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def get_new_snapshot_name(self) -> str:
+        return f"{self.path.name}.NEW.{os.getpid()}"
+
+    def get_snapshot_name(self, info: SubvolInfo) -> str:
+        ctime = arrow.get(info.ctime, tzinfo=TZINFO.get())
+        ctime_str = ctime.isoformat(timespec="seconds")
+        return f"{self.path.name}.{ctime_str}.{info.ctransid}"
+
+    def get_backup_key(self, info: BackupInfo) -> str:
+        suffixes = info.get_path_suffixes(tzinfo=TZINFO.get())
+        return f"{self.path.name}{''.join(suffixes)}"
+
+    def close(self) -> None:
+        os.close(self._fd)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+
+def _is_subvol(fd: int) -> bool:
+    return os.stat(fd).st_ino == FIRST_FREE_OBJECTID  # noqa: PTH116
+
+
+def _iter_snapshots(dir_fd: int) -> Iterator[tuple[str, SubvolInfo]]:
+    for name in os.listdir(dir_fd):
+        with opendir(name, dir_fd=dir_fd) as fd:
+            if not _is_subvol(fd):
+                continue
+            info = subvol_info(fd)
+            if info.parent_uuid is None:
+                continue
+            if not info.flags & SubvolFlag.ReadOnly:
+                continue
+            yield (name, info)
+
+
+class SnapshotDir:
+    @classmethod
+    def create(cls, path: Path) -> Self:
+        dir_fd = os.open(path, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            # raise an error if the dir isn't on a btrfs mountpoint, even if
+            # it's empty
+            subvol_info(dir_fd)
+            snapshots = list(_iter_snapshots(dir_fd))
+            return cls(path=path, dir_fd=dir_fd, snapshots=snapshots)
+        except Exception:
+            os.close(dir_fd)
+            raise
+
+    def __init__(
+        self, *, path: Path, dir_fd: int, snapshots: Collection[tuple[str, SubvolInfo]]
+    ) -> None:
+        self._path = path
+        self._dir_fd = dir_fd
+        self._id_to_snapshot: dict[int, SubvolInfo] = {}
+        self._id_to_name: dict[int, str] = {}
+        self._p_to_u_to_snapshot: dict[bytes, dict[bytes, SubvolInfo]] = defaultdict(
+            dict
+        )
+        for name, snap in snapshots:
+            self._add_snapshot(name, snap)
+
+    def _add_snapshot(self, name: str, snap: SubvolInfo) -> None:
+        id_ = snap.id
+        u = snap.uuid
+        p = snap.parent_uuid
+        assert p is not None
+        assert id_ not in self._id_to_name
+        self._id_to_name[id_] = name
+        assert id_ not in self._id_to_snapshot
+        self._id_to_snapshot[id_] = snap
+        assert u not in self._p_to_u_to_snapshot[p]
+        self._p_to_u_to_snapshot[p][u] = snap
+
+    def _remove_snapshot(self, snapshot_id: int) -> None:
+        snap = self._id_to_snapshot[snapshot_id]
+        u = snap.uuid
+        p = snap.parent_uuid
+        assert p is not None
+        del self._id_to_name[snapshot_id]
+        del self._id_to_snapshot[snapshot_id]
+        del self._p_to_u_to_snapshot[p][u]
+
+    def get_name(self, snapshot_id: int) -> str:
+        return self._id_to_name[snapshot_id]
+
+    def get_path(self, snapshot_id: int) -> Path:
+        return self.path / self.get_name(snapshot_id)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def get_snapshots(self, source: Source) -> Mapping[bytes, SubvolInfo]:
+        return self._p_to_u_to_snapshot.get(source.info.uuid, {})
+
+    def create_snapshot(self, source: Source, name: str) -> SubvolInfo:
+        _LOG.info(
+            "creating read-only snapshot of %s at %s", source.path, self.path / name
+        )
+        create_snap(src=source.fd, dst=name, dst_dir_fd=self._dir_fd, read_only=True)
+        snap = subvol_info(name, dir_fd=self._dir_fd)
+        self._add_snapshot(name, snap)
+        return snap
+
+    def destroy_snapshot(self, snapshot_id: int) -> None:
+        self._id_to_snapshot[snapshot_id]
+        _LOG.info("destroying read-only snapshot %s", self.get_path(snapshot_id))
+        destroy_snap(dir_fd=self._dir_fd, snapshot_id=snapshot_id)
+        self._remove_snapshot(snapshot_id)
+
+    def rename_snapshot(self, snapshot_id: int, target: str) -> None:
+        name = self.get_name(snapshot_id)
+        _LOG.info("renaming %s -> %s", self.path / name, self.path / target)
+        os.rename(name, target, src_dir_fd=self._dir_fd, dst_dir_fd=self._dir_fd)  # noqa: PTH104
+        self._id_to_name[snapshot_id] = target
+
+    def send(
+        self,
+        *,
+        dst: int | IO[bytes],
+        snapshot_id: int,
+        parent_id: int = 0,
+        proto: int | None = None,
+        flags: int = 0,
+    ) -> None:
+        name = self.get_name(snapshot_id)
+        with opendir(name, dir_fd=self._dir_fd) as fd:
+            snap = subvol_info(fd)
+            if snap.id != snapshot_id:
+                msg = (
+                    "snapshot moved or renamed since we started: "
+                    f"{self.get_path(snapshot_id)} was subvol {snapshot_id}, "
+                    f"now it's {snap.id}"
+                )
+                raise RuntimeError(msg)
+            send(src=fd, dst=dst, parent_id=parent_id, proto=proto, flags=flags)
+
+    def close(self) -> None:
+        os.close(self._dir_fd)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+
+DEFAULT_PART_SIZE = 5 * 2**30
+
+
+class CreatePipe(Protocol):
+    def __call__(self) -> AbstractContextManager[tuple[IO[bytes], IO[bytes]]]: ...
+
+
+class ObjectStat(NamedTuple):
+    size: int | None = None
+    storage_class: str | None = None
+
+    @classmethod
+    def from_obj(cls, obj: ObjectTypeDef) -> Self:
+        return cls(size=obj.get("Size"), storage_class=obj.get("StorageClass"))
+
+
+class BackupObject(NamedTuple):
+    key: str
+    info: BackupInfo
+    stat: ObjectStat
+
+
+class Remote:
+    @classmethod
+    def create(cls, *, name: str, s3: S3Client, bucket: str) -> Self:
+        return cls(
+            name=name,
+            s3=s3,
+            bucket=bucket,
+            objects=[
+                BackupObject(key=obj["Key"], info=info, stat=ObjectStat.from_obj(obj))
+                for obj, info in iter_backups(s3, bucket)
+            ],
+        )
+
+    def __init__(
+        self, *, name: str, s3: S3Client, bucket: str, objects: Collection[BackupObject]
+    ) -> None:
+        self._name = name
+        self._s3 = s3
+        self._bucket = bucket
+        self._p_to_u_to_obj: dict[bytes, dict[bytes, BackupObject]] = defaultdict(dict)
+        self._u_to_obj: dict[bytes, BackupObject] = {}
+        for obj in objects:
+            self._add_object(obj)
+
+    def _add_object(self, obj: BackupObject) -> None:
+        u = obj.info.uuid
+        p = obj.info.parent_uuid
+        assert u not in self._p_to_u_to_obj[p]
+        self._p_to_u_to_obj[p][u] = obj
+        assert u not in self._u_to_obj
+        self._u_to_obj[u] = obj
+
+    def _remove_object(self, u: bytes) -> None:
+        obj = self._u_to_obj[u]
+        del self._u_to_obj[u]
+        del self._p_to_u_to_obj[obj.info.parent_uuid][u]
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def s3(self) -> S3Client:
+        return self._s3
+
+    @property
+    def bucket(self) -> str:
+        return self._bucket
+
+    def get_objects(self, source: Source) -> Mapping[bytes, BackupObject]:
+        return self._p_to_u_to_obj.get(source.info.uuid, {})
+
+    def upload(
+        self,
+        *,
+        snapshot_dir: SnapshotDir,
+        snapshot_id: int,
+        send_parent_id: int | None,
+        key: str,
+        create_pipe: CreatePipe,
+    ) -> ObjectStat:
+        _LOG.info(
+            "creating backup of %s (%s) on %s",
+            snapshot_dir.get_path(snapshot_id),
+            f"differential from {snapshot_dir.get_path(send_parent_id)}"
+            if send_parent_id
+            else "full",
+            self.name,
+        )
+
+        try:
+            with ExitStack() as stack:
+                # The stack order is important. On an error, we want to close
+                # the pipe first. This will allow the send() and upload to
+                # fail.
+                executor = stack.enter_context(ThreadPoolExecutor())
+                r, w = stack.enter_context(create_pipe())
+
+                def send() -> None:
+                    # close the pipe when the send completes
+                    with w:
+                        snapshot_dir.send(
+                            dst=w,
+                            snapshot_id=snapshot_id,
+                            parent_id=send_parent_id or 0,
+                        )
+
+                send_future = executor.submit(send)
+                upload_non_seekable_stream_via_tempfile(
+                    client=self._s3,
+                    bucket=self._bucket,
+                    key=key,
+                    stream=r,
+                    part_size=DEFAULT_PART_SIZE,
+                )
+                send_future.result()
+        except BaseException:
+            # Assume the backup is corrupted
+            self._s3.delete_objects(
+                Bucket=self._bucket, Delete={"Quiet": True, "Objects": [{"Key": key}]}
+            )
+            raise
+
+        stat = ObjectStat()
+        self._add_object(
+            BackupObject(key=key, info=BackupInfo.from_path(key), stat=stat)
+        )
+        return stat
+
+    def delete(self, *keys: str) -> None:
+        for i in range(0, len(keys), 1000):
+            batch = keys[i : i + 1000]
+            for key in batch:
+                _LOG.info("deleting backup %s", key)
+            # Do we need to inspect the response for individual errors, or will we
+            # raise an exception in this case? The docs are thousands of words long
+            # but don't explain this
+            self._s3.delete_objects(
+                Bucket=self._bucket,
+                Delete={"Quiet": True, "Objects": [{"Key": key} for key in batch]},
+            )
+            for key in batch:
+                self._remove_object(BackupInfo.from_path(key).uuid)
+
+
+class ConfigTuple(NamedTuple):
+    source: Source
+    snapshot_dir: SnapshotDir
+    remote: Remote
+    policy: Policy
+    create_pipe: CreatePipe
+
+
+class AssessedSnapshot(NamedTuple):
+    source: Source
+    snapshot_dir: SnapshotDir
+    info: SubvolInfo
+    meta: KeepMeta
+
+
+class AssessedBackup(NamedTuple):
+    source: Source
+    remote: Remote
+    info: BackupInfo
+    stat: ObjectStat | None
+    key: str
+    meta: KeepMeta
+    create_pipe: CreatePipe
+
+
+class Assessment(NamedTuple):
+    snapshots: dict[bytes, AssessedSnapshot]
+    backups: dict[tuple[Remote, bytes], AssessedBackup]
+
+
+def _maybe_create_snapshot(
+    source: Source, snapshot_dir: SnapshotDir
+) -> SubvolInfo | None:
+    snaps = snapshot_dir.get_snapshots(source)
+    if snaps:
+        max_ctransid = max(snap.ctransid for snap in snaps.values())
+        if source.info.ctransid <= max_ctransid:
+            return None
+    return snapshot_dir.create_snapshot(source, source.get_new_snapshot_name())
+
+
+def destroy_new_snapshots(asmt: Assessment) -> None:
+    for snap in asmt.snapshots.values():
+        if snap.meta.flags & Flags.New:
+            snap.snapshot_dir.destroy_snapshot(snap.info.id)
+
+
+def assess(*cfg_tuples: ConfigTuple) -> Assessment:
+    snap_meta: dict[bytes, KeepMeta] = {}
+    snaps: dict[bytes, AssessedSnapshot] = {}
+    backups: dict[tuple[Remote, bytes], AssessedBackup] = {}
+
+    for cfg_tuple in cfg_tuples:
+        created_info = _maybe_create_snapshot(cfg_tuple.source, cfg_tuple.snapshot_dir)
+        if created_info is not None:
+            snap_meta[created_info.uuid] = KeepMeta(flags=Flags.New)
+
+        tuple_snaps = cfg_tuple.snapshot_dir.get_snapshots(cfg_tuple.source)
+
+        for uuid, info in tuple_snaps.items():
+            snap = snaps.get(uuid)
+            if not snap:
+                snaps[uuid] = AssessedSnapshot(
+                    source=cfg_tuple.source,
+                    snapshot_dir=cfg_tuple.snapshot_dir,
+                    info=info,
+                    meta=snap_meta.get(uuid) or KeepMeta(),
+                )
+            else:
+                assert snap.snapshot_dir is cfg_tuple.snapshot_dir
+
+        tuple_objects = cfg_tuple.remote.get_objects(cfg_tuple.source)
+        for uuid, obj in tuple_objects.items():
+            assert (cfg_tuple.remote, uuid) not in backups
+            backups[(cfg_tuple.remote, uuid)] = AssessedBackup(
+                source=cfg_tuple.source,
+                remote=cfg_tuple.remote,
+                info=obj.info,
+                stat=obj.stat,
+                key=obj.key,
+                meta=KeepMeta(),
+                create_pipe=cfg_tuple.create_pipe,
+            )
+
+        result = resolve(
+            snapshots=tuple_snaps.values(),
+            backups=[obj.info for obj in tuple_objects.values()],
+            policy=cfg_tuple.policy,
+            mk_backup=backup_of_snapshot,
+        )
+
+        for uuid, result_snap in result.keep_snapshots.items():
+            snaps[uuid] = snaps[uuid]._replace(meta=snaps[uuid].meta | result_snap.meta)
+
+        for uuid, result_backup in result.keep_backups.items():
+            backup = backups.get((cfg_tuple.remote, uuid))
+            if backup:
+                # keep an existing backup
+                backups[(cfg_tuple.remote, uuid)] = backup._replace(
+                    meta=backup.meta | result_backup.meta
+                )
+            else:
+                # keep a new backup
+                backups[(cfg_tuple.remote, uuid)] = AssessedBackup(
+                    source=cfg_tuple.source,
+                    remote=cfg_tuple.remote,
+                    info=result_backup.item,
+                    stat=None,
+                    key=cfg_tuple.source.get_backup_key(result_backup.item),
+                    meta=result_backup.meta,
+                    create_pipe=cfg_tuple.create_pipe,
+                )
+
+    return Assessment(snapshots=snaps, backups=backups)
+
+
+def assessment_to_actions(asmt: Assessment) -> Actions:
+    rename_snapshots = []
+    destroy_snapshots = []
+    upload_backups = []
+    delete_backups = []
+
+    for snap in asmt.snapshots.values():
+        if snap.meta.reasons:
+            name = snap.snapshot_dir.get_name(snap.info.id)
+            target_name = snap.source.get_snapshot_name(snap.info)
+            if name != target_name:
+                rename_snapshots.append(
+                    RenameSnapshot(
+                        snapshot_dir=snap.snapshot_dir,
+                        info=snap.info,
+                        target_name=target_name,
+                    )
+                )
+        else:
+            destroy_snapshots.append(
+                DestroySnapshot(snapshot_dir=snap.snapshot_dir, info=snap.info)
+            )
+
+    for (_, uuid), backup in asmt.backups.items():
+        if backup.meta.reasons:
+            if backup.meta.flags & Flags.New:
+                if backup.info.send_parent_uuid:
+                    send_parent = asmt.snapshots[backup.info.send_parent_uuid].info
+                else:
+                    send_parent = None
+                upload_backups.append(
+                    UploadBackup(
+                        remote=backup.remote,
+                        key=backup.key,
+                        snapshot_dir=asmt.snapshots[uuid].snapshot_dir,
+                        info=asmt.snapshots[uuid].info,
+                        send_parent=send_parent,
+                        create_pipe=backup.create_pipe,
+                    )
+                )
+        else:
+            assert backup.stat is not None
+            delete_backups.append(
+                DeleteBackup(
+                    remote=backup.remote,
+                    key=backup.key,
+                    info=backup.info,
+                    stat=backup.stat,
+                )
+            )
+
+    rename_snapshots.sort(key=lambda args: args.snapshot_dir.get_path(args.info.id))
+    upload_backups.sort(key=lambda args: args.snapshot_dir.get_path(args.info.id))
+    destroy_snapshots.sort(key=lambda args: args.snapshot_dir.get_path(args.info.id))
+    delete_backups.sort(key=lambda args: (args.remote.name, args.key))
+
+    return Actions(
+        rename_snapshots=rename_snapshots,
+        upload_backups=upload_backups,
+        destroy_snapshots=destroy_snapshots,
+        delete_backups=delete_backups,
+    )
+
+
+class RenameSnapshot(NamedTuple):
+    snapshot_dir: SnapshotDir
+    info: SubvolInfo
+    target_name: str
+
+    def __call__(self) -> None:
+        self.snapshot_dir.rename_snapshot(self.info.id, self.target_name)
+
+
+class DestroySnapshot(NamedTuple):
+    snapshot_dir: SnapshotDir
+    info: SubvolInfo
+
+    def __call__(self) -> None:
+        self.snapshot_dir.destroy_snapshot(self.info.id)
+
+
+class UploadBackup(NamedTuple):
+    remote: Remote
+    key: str
+    snapshot_dir: SnapshotDir
+    info: SubvolInfo
+    send_parent: SubvolInfo | None
+    create_pipe: CreatePipe
+
+    def __call__(self) -> None:
+        self.remote.upload(
+            snapshot_dir=self.snapshot_dir,
+            snapshot_id=self.info.id,
+            send_parent_id=self.send_parent.id if self.send_parent else None,
+            key=self.key,
+            create_pipe=self.create_pipe,
+        )
+
+
+class DeleteBackup(NamedTuple):
+    remote: Remote
+    key: str
+    info: BackupInfo
+    stat: ObjectStat
+
+
+def delete_backups(*delete_backups: DeleteBackup) -> None:
+    remote_to_delete_keys: dict[Remote, list[str]] = defaultdict(list)
+    for delete_backup_intent in delete_backups:
+        remote_to_delete_keys[delete_backup_intent.remote].append(
+            delete_backup_intent.key
+        )
+    for remote, delete_keys in remote_to_delete_keys.items():
+        remote.delete(*delete_keys)
+
+
+class Actions(NamedTuple):
+    rename_snapshots: list[RenameSnapshot]
+    upload_backups: list[UploadBackup]
+    destroy_snapshots: list[DestroySnapshot]
+    delete_backups: list[DeleteBackup]
+
+    def any_actions(self) -> bool:
+        return bool(
+            self.rename_snapshots
+            or self.upload_backups
+            or self.destroy_snapshots
+            or self.delete_backups
+        )
+
+    def execute(self) -> None:
+        for rename_snapshot in self.rename_snapshots:
+            rename_snapshot()
+        for upload_backup in self.upload_backups:
+            upload_backup()
+        for destroy_snapshot in self.destroy_snapshots:
+            destroy_snapshot()
+
+        delete_backups(*self.delete_backups)

--- a/src/btrfs2s3/_internal/util.py
+++ b/src/btrfs2s3/_internal/util.py
@@ -1,6 +1,6 @@
 # btrfs2s3 - maintains a tree of differential backups in object storage.
 #
-# Copyright (C) 2024 Steven Brudenell and other contributors.
+# Copyright (C) 2024-2025 Steven Brudenell and other contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,15 +17,35 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+from contextvars import ContextVar
 from enum import IntFlag
 from typing import Protocol
+from typing import TYPE_CHECKING
 from typing import TypeVar
 
 from btrfsutil import SubvolumeInfo
 
 from btrfs2s3._internal.backups import BackupInfo
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from datetime import tzinfo
+
+
 NULL_UUID = b"\0" * 16
+
+
+TZINFO: ContextVar[tzinfo] = ContextVar("tzinfo")
+
+
+@contextmanager
+def use_tzinfo(tz: tzinfo) -> Iterator[None]:
+    token = TZINFO.set(tz)
+    try:
+        yield
+    finally:
+        TZINFO.reset(token)
 
 
 def mksubvol(

--- a/tests/assessor/assess_test.py
+++ b/tests/assessor/assess_test.py
@@ -1,6 +1,6 @@
 # btrfs2s3 - maintains a tree of differential backups in object storage.
 #
-# Copyright (C) 2024 Steven Brudenell and other contributors.
+# Copyright (C) 2024-2025 Steven Brudenell and other contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,7 +17,11 @@
 
 from __future__ import annotations
 
+from enum import auto
+from enum import Enum
+from functools import partial
 import time
+from typing import cast
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
@@ -29,6 +33,15 @@ from btrfs2s3._internal.action import Actions
 from btrfs2s3._internal.assessor import assess
 from btrfs2s3._internal.assessor import assessment_to_actions
 from btrfs2s3._internal.backups import BackupInfo
+from btrfs2s3._internal.piper import filter_pipe
+from btrfs2s3._internal.planner import assess as planner_assess
+from btrfs2s3._internal.planner import (
+    assessment_to_actions as planner_assessment_to_actions,
+)
+from btrfs2s3._internal.planner import ConfigTuple
+from btrfs2s3._internal.planner import Remote
+from btrfs2s3._internal.planner import SnapshotDir
+from btrfs2s3._internal.planner import Source
 from btrfs2s3._internal.preservation import Params
 from btrfs2s3._internal.preservation import Policy
 from btrfs2s3._internal.resolver import Flags
@@ -47,11 +60,22 @@ if TYPE_CHECKING:
     from tests.conftest import DownloadAndPipe
 
 
+class Impl(Enum):
+    Assessor = auto()
+    Planner = auto()
+
+
+@pytest.fixture(params=[Impl.Assessor, Impl.Planner])
+def impl(request: pytest.FixtureRequest) -> Impl:
+    return cast(Impl, request.param)
+
+
 def test_create_and_backup_new_snapshot(
     btrfs_mountpoint: Path,
     s3: S3Client,
     bucket: str,
     download_and_pipe: DownloadAndPipe,
+    impl: Impl,
 ) -> None:
     # Create a subvolume
     source = btrfs_mountpoint / "source"
@@ -63,48 +87,68 @@ def test_create_and_backup_new_snapshot(
     (source / "dummy-file").write_bytes(b"dummy")
     btrfsutil.sync(source)
 
-    assessment = assess(
-        snapshot_dir=snapshot_dir,
-        sources=(source,),
-        s3=s3,
-        bucket=bucket,
-        policy=Policy(),
-    )
+    if impl == Impl.Assessor:
+        assessment = assess(
+            snapshot_dir=snapshot_dir,
+            sources=(source,),
+            s3=s3,
+            bucket=bucket,
+            policy=Policy(),
+        )
 
-    (source_asmt,) = list(assessment.sources.values())
-    # We should only keep one proposed snapshot
-    (snapshot_asmt,) = list(source_asmt.snapshots.values())
-    proposed_info = snapshot_asmt.info
-    assert proposed_info.uuid != NULL_UUID
-    assert proposed_info.parent_uuid == btrfsutil.subvolume_info(source).uuid
-    want_flags = SubvolumeFlags.Proposed | SubvolumeFlags.ReadOnly
-    assert proposed_info.flags & want_flags == want_flags
-    assert snapshot_asmt.keep_meta == KeepMeta(
-        reasons=Reasons.MostRecent, flags=Flags.New
-    )
-    assert snapshot_asmt.new
+        (source_asmt,) = list(assessment.sources.values())
+        # We should only keep one proposed snapshot
+        (snapshot_asmt,) = list(source_asmt.snapshots.values())
+        proposed_info = snapshot_asmt.info
+        assert proposed_info.uuid != NULL_UUID
+        assert proposed_info.parent_uuid == btrfsutil.subvolume_info(source).uuid
+        want_flags = SubvolumeFlags.Proposed | SubvolumeFlags.ReadOnly
+        assert proposed_info.flags & want_flags == want_flags
+        assert snapshot_asmt.keep_meta == KeepMeta(
+            reasons=Reasons.MostRecent, flags=Flags.New
+        )
+        assert snapshot_asmt.new
 
-    # We should only keep one proposed full backup
-    ((backup_uuid, backup_asmt),) = list(source_asmt.backups.items())
-    assert backup_uuid == proposed_info.uuid
-    assert backup_asmt.keep_meta == KeepMeta(
-        reasons=Reasons.MostRecent, flags=Flags.New
-    )
-    assert backup_asmt.new
+        # We should only keep one proposed full backup
+        ((backup_uuid, backup_asmt),) = list(source_asmt.backups.items())
+        assert backup_uuid == proposed_info.uuid
+        assert backup_asmt.keep_meta == KeepMeta(
+            reasons=Reasons.MostRecent, flags=Flags.New
+        )
+        assert backup_asmt.new
 
-    actions = Actions()
-    assessment_to_actions(assessment, actions)
+        actions = Actions()
+        assessment_to_actions(assessment, actions)
 
-    (create_snapshot_intent,) = list(actions.iter_create_snapshot_intents())
-    assert create_snapshot_intent.source.peek() == source
-    assert snapshot_dir in create_snapshot_intent.path().parents
-    assert create_snapshot_intent.path().name.startswith(source.name)
-    (rename_snapshot_intent,) = list(actions.iter_rename_snapshot_intents())
-    assert rename_snapshot_intent.source.peek() == create_snapshot_intent.path.peek()
-    (create_backup_intent,) = list(actions.iter_create_backup_intents())
-    assert create_backup_intent.source.peek() == source
+        (create_snapshot_intent,) = list(actions.iter_create_snapshot_intents())
+        assert create_snapshot_intent.source.peek() == source
+        assert snapshot_dir in create_snapshot_intent.path().parents
+        assert create_snapshot_intent.path().name.startswith(source.name)
+        (rename_snapshot_intent,) = list(actions.iter_rename_snapshot_intents())
+        assert (
+            rename_snapshot_intent.source.peek() == create_snapshot_intent.path.peek()
+        )
+        (create_backup_intent,) = list(actions.iter_create_backup_intents())
+        assert create_backup_intent.source.peek() == source
 
-    actions.execute(s3, bucket)
+        actions.execute(s3, bucket)
+    else:
+        remote = Remote.create(name="test", s3=s3, bucket=bucket)
+        with (
+            Source.create(source) as source_,
+            SnapshotDir.create(snapshot_dir) as snapshot_dir_,
+        ):
+            assessment_ = planner_assess(
+                ConfigTuple(
+                    source=source_,
+                    snapshot_dir=snapshot_dir_,
+                    remote=remote,
+                    policy=Policy(),
+                    create_pipe=partial(filter_pipe, []),
+                )
+            )
+            actions_ = planner_assessment_to_actions(assessment_)
+            actions_.execute()
 
     (snapshot,) = list(snapshot_dir.iterdir())
     assert snapshot.name.startswith(source.name)
@@ -124,6 +168,7 @@ def test_create_and_backup_with_parent(  # noqa: PLR0915
     s3: S3Client,
     bucket: str,
     download_and_pipe: DownloadAndPipe,
+    impl: Impl,
 ) -> None:
     # Create a subvolume
     source = btrfs_mountpoint / "source"
@@ -145,48 +190,73 @@ def test_create_and_backup_with_parent(  # noqa: PLR0915
     now = time.time()
     policy = Policy(now=now, params=Params(years=1))
     expected_time_span = next(policy.iter_time_spans(now))
-    assessment = assess(
-        snapshot_dir=snapshot_dir,
-        sources=(source,),
-        s3=s3,
-        bucket=bucket,
-        policy=policy,
-    )
 
-    (source_asmt,) = list(assessment.sources.values())
-    (old_asmt, new_asmt) = sorted(source_asmt.snapshots.values(), key=lambda a: a.new)
-    # One assessment for the new snapshot
-    proposed_info = new_asmt.info
-    assert proposed_info.uuid != NULL_UUID
-    assert proposed_info.parent_uuid == btrfsutil.subvolume_info(source).uuid
-    want_flags = SubvolumeFlags.Proposed | SubvolumeFlags.ReadOnly
-    assert proposed_info.flags & want_flags == want_flags
-    assert new_asmt.keep_meta == KeepMeta(reasons=Reasons.MostRecent, flags=Flags.New)
-    assert new_asmt.new
-    # One assessment for the existing snapshot
-    assert old_asmt.info.uuid == btrfsutil.subvolume_info(snapshot1).uuid
-    assert old_asmt.keep_meta == KeepMeta(
-        reasons=Reasons.Preserved, time_spans={expected_time_span}
-    )
-    assert not old_asmt.new
+    if impl == Impl.Assessor:
+        assessment = assess(
+            snapshot_dir=snapshot_dir,
+            sources=(source,),
+            s3=s3,
+            bucket=bucket,
+            policy=policy,
+        )
 
-    # One backup assessment will match the uuid of the existing snapshot, but
-    # the other will match a proposed uuid
-    full_asmt = source_asmt.backups[old_asmt.info.uuid]
-    delta_asmt = source_asmt.backups[new_asmt.info.uuid]
-    assert full_asmt.backup.check().uuid == old_asmt.info.uuid
-    assert full_asmt.backup.check().send_parent_uuid is None
-    assert full_asmt.keep_meta == KeepMeta(
-        reasons=Reasons.Preserved, flags=Flags.New, time_spans={expected_time_span}
-    )
-    assert full_asmt.new
-    assert delta_asmt.keep_meta == KeepMeta(reasons=Reasons.MostRecent, flags=Flags.New)
-    assert delta_asmt.new
+        (source_asmt,) = list(assessment.sources.values())
+        (old_asmt, new_asmt) = sorted(
+            source_asmt.snapshots.values(), key=lambda a: a.new
+        )
+        # One assessment for the new snapshot
+        proposed_info = new_asmt.info
+        assert proposed_info.uuid != NULL_UUID
+        assert proposed_info.parent_uuid == btrfsutil.subvolume_info(source).uuid
+        want_flags = SubvolumeFlags.Proposed | SubvolumeFlags.ReadOnly
+        assert proposed_info.flags & want_flags == want_flags
+        assert new_asmt.keep_meta == KeepMeta(
+            reasons=Reasons.MostRecent, flags=Flags.New
+        )
+        assert new_asmt.new
+        # One assessment for the existing snapshot
+        assert old_asmt.info.uuid == btrfsutil.subvolume_info(snapshot1).uuid
+        assert old_asmt.keep_meta == KeepMeta(
+            reasons=Reasons.Preserved, time_spans={expected_time_span}
+        )
+        assert not old_asmt.new
 
-    actions = Actions()
-    assessment_to_actions(assessment, actions)
+        # One backup assessment will match the uuid of the existing snapshot, but
+        # the other will match a proposed uuid
+        full_asmt = source_asmt.backups[old_asmt.info.uuid]
+        delta_asmt = source_asmt.backups[new_asmt.info.uuid]
+        assert full_asmt.backup.check().uuid == old_asmt.info.uuid
+        assert full_asmt.backup.check().send_parent_uuid is None
+        assert full_asmt.keep_meta == KeepMeta(
+            reasons=Reasons.Preserved, flags=Flags.New, time_spans={expected_time_span}
+        )
+        assert full_asmt.new
+        assert delta_asmt.keep_meta == KeepMeta(
+            reasons=Reasons.MostRecent, flags=Flags.New
+        )
+        assert delta_asmt.new
 
-    actions.execute(s3, bucket)
+        actions = Actions()
+        assessment_to_actions(assessment, actions)
+
+        actions.execute(s3, bucket)
+    else:
+        remote = Remote.create(name="test", s3=s3, bucket=bucket)
+        with (
+            Source.create(source) as source_,
+            SnapshotDir.create(snapshot_dir) as snapshot_dir_,
+        ):
+            assessment_ = planner_assess(
+                ConfigTuple(
+                    source=source_,
+                    snapshot_dir=snapshot_dir_,
+                    remote=remote,
+                    policy=policy,
+                    create_pipe=partial(filter_pipe, []),
+                )
+            )
+            actions_ = planner_assessment_to_actions(assessment_)
+            actions_.execute()
 
     (snapshot1, snapshot2) = snapshot_dir.iterdir()
     assert snapshot1.name.startswith(source.name)
@@ -217,6 +287,7 @@ def test_rename_snapshot(
     s3: S3Client,
     bucket: str,
     download_and_pipe: DownloadAndPipe,
+    impl: Impl,
 ) -> None:
     # Create a subvolume
     source = btrfs_mountpoint / "source"
@@ -231,43 +302,61 @@ def test_rename_snapshot(
     btrfsutil.create_snapshot(source, snapshot, read_only=True)
     btrfsutil.sync(source)
 
-    assessment = assess(
-        snapshot_dir=snapshot_dir,
-        sources=(source,),
-        s3=s3,
-        bucket=bucket,
-        policy=Policy(),
-    )
+    if impl == Impl.Assessor:
+        assessment = assess(
+            snapshot_dir=snapshot_dir,
+            sources=(source,),
+            s3=s3,
+            bucket=bucket,
+            policy=Policy(),
+        )
 
-    (source_asmt,) = list(assessment.sources.values())
-    # Keep only the existing snapshot
-    (snapshot_asmt,) = list(source_asmt.snapshots.values())
-    assert snapshot_asmt.info.uuid == btrfsutil.subvolume_info(snapshot).uuid
-    assert snapshot_asmt.info.parent_uuid == btrfsutil.subvolume_info(source).uuid
-    check_flags = SubvolumeFlags.Proposed | SubvolumeFlags.ReadOnly
-    want_flags = SubvolumeFlags.ReadOnly
-    assert snapshot_asmt.info.flags & check_flags == want_flags
-    assert snapshot_asmt.target_path.check().name.startswith(source.name)
-    assert snapshot_asmt.keep_meta == KeepMeta(reasons=Reasons.MostRecent)
-    assert not snapshot_asmt.new
+        (source_asmt,) = list(assessment.sources.values())
+        # Keep only the existing snapshot
+        (snapshot_asmt,) = list(source_asmt.snapshots.values())
+        assert snapshot_asmt.info.uuid == btrfsutil.subvolume_info(snapshot).uuid
+        assert snapshot_asmt.info.parent_uuid == btrfsutil.subvolume_info(source).uuid
+        check_flags = SubvolumeFlags.Proposed | SubvolumeFlags.ReadOnly
+        want_flags = SubvolumeFlags.ReadOnly
+        assert snapshot_asmt.info.flags & check_flags == want_flags
+        assert snapshot_asmt.target_path.check().name.startswith(source.name)
+        assert snapshot_asmt.keep_meta == KeepMeta(reasons=Reasons.MostRecent)
+        assert not snapshot_asmt.new
 
-    # We should only keep one full backup, of the existing snapshot
-    ((backup_uuid, backup_asmt),) = list(source_asmt.backups.items())
-    assert backup_uuid == snapshot_asmt.info.uuid
-    assert backup_asmt.keep_meta == KeepMeta(
-        reasons=Reasons.MostRecent, flags=Flags.New
-    )
-    assert backup_asmt.new
+        # We should only keep one full backup, of the existing snapshot
+        ((backup_uuid, backup_asmt),) = list(source_asmt.backups.items())
+        assert backup_uuid == snapshot_asmt.info.uuid
+        assert backup_asmt.keep_meta == KeepMeta(
+            reasons=Reasons.MostRecent, flags=Flags.New
+        )
+        assert backup_asmt.new
 
-    actions = Actions()
-    assessment_to_actions(assessment, actions)
+        actions = Actions()
+        assessment_to_actions(assessment, actions)
 
-    (rename_snapshot_intent,) = list(actions.iter_rename_snapshot_intents())
-    assert rename_snapshot_intent.source.peek() == snapshot
-    (create_backup_intent,) = list(actions.iter_create_backup_intents())
-    assert create_backup_intent.source.peek() == source
+        (rename_snapshot_intent,) = list(actions.iter_rename_snapshot_intents())
+        assert rename_snapshot_intent.source.peek() == snapshot
+        (create_backup_intent,) = list(actions.iter_create_backup_intents())
+        assert create_backup_intent.source.peek() == source
 
-    actions.execute(s3, bucket)
+        actions.execute(s3, bucket)
+    else:
+        remote = Remote.create(name="test", s3=s3, bucket=bucket)
+        with (
+            Source.create(source) as source_,
+            SnapshotDir.create(snapshot_dir) as snapshot_dir_,
+        ):
+            assessment_ = planner_assess(
+                ConfigTuple(
+                    source=source_,
+                    snapshot_dir=snapshot_dir_,
+                    remote=remote,
+                    policy=Policy(),
+                    create_pipe=partial(filter_pipe, []),
+                )
+            )
+            actions_ = planner_assessment_to_actions(assessment_)
+            actions_.execute()
 
     (snapshot,) = list(snapshot_dir.iterdir())
     assert snapshot.name.startswith(source.name)
@@ -282,11 +371,12 @@ def test_rename_snapshot(
     download_and_pipe(obj["Key"], ["btrfs", "receive", "--dump"])
 
 
-def test_delete_only_snapshot_because_proposed_would_be_newer(
+def test_delete_only_snapshot_because_proposed_would_be_newer(  # noqa: PLR0915
     btrfs_mountpoint: Path,
     s3: S3Client,
     bucket: str,
     download_and_pipe: DownloadAndPipe,
+    impl: Impl,
 ) -> None:
     # Create a subvolume
     source = btrfs_mountpoint / "source"
@@ -303,53 +393,77 @@ def test_delete_only_snapshot_because_proposed_would_be_newer(
     (source / "dummy-file").write_bytes(b"dummy2")
     btrfsutil.sync(source)
 
-    assessment = assess(
-        snapshot_dir=snapshot_dir,
-        sources=(source,),
-        s3=s3,
-        bucket=bucket,
-        policy=Policy(),
-    )
+    if impl == Impl.Assessor:
+        assessment = assess(
+            snapshot_dir=snapshot_dir,
+            sources=(source,),
+            s3=s3,
+            bucket=bucket,
+            policy=Policy(),
+        )
 
-    (source_asmt,) = list(assessment.sources.values())
-    # Two assessments: one for the existing snapshot, one proposed
-    (old_asmt, new_asmt) = sorted(source_asmt.snapshots.values(), key=lambda a: a.new)
-    proposed_info = new_asmt.info
-    assert proposed_info.uuid != NULL_UUID
-    assert proposed_info.parent_uuid == btrfsutil.subvolume_info(source).uuid
-    want_flags = SubvolumeFlags.Proposed | SubvolumeFlags.ReadOnly
-    assert proposed_info.flags & want_flags == want_flags
-    assert new_asmt.keep_meta == KeepMeta(reasons=Reasons.MostRecent, flags=Flags.New)
-    assert new_asmt.new
-    # Assessment of the existing snapshot
-    assert old_asmt.info.uuid == btrfsutil.subvolume_info(initial_snapshot).uuid
-    assert old_asmt.initial_path == initial_snapshot
-    assert old_asmt.keep_meta == KeepMeta()
-    assert not old_asmt.new
+        (source_asmt,) = list(assessment.sources.values())
+        # Two assessments: one for the existing snapshot, one proposed
+        (old_asmt, new_asmt) = sorted(
+            source_asmt.snapshots.values(), key=lambda a: a.new
+        )
+        proposed_info = new_asmt.info
+        assert proposed_info.uuid != NULL_UUID
+        assert proposed_info.parent_uuid == btrfsutil.subvolume_info(source).uuid
+        want_flags = SubvolumeFlags.Proposed | SubvolumeFlags.ReadOnly
+        assert proposed_info.flags & want_flags == want_flags
+        assert new_asmt.keep_meta == KeepMeta(
+            reasons=Reasons.MostRecent, flags=Flags.New
+        )
+        assert new_asmt.new
+        # Assessment of the existing snapshot
+        assert old_asmt.info.uuid == btrfsutil.subvolume_info(initial_snapshot).uuid
+        assert old_asmt.initial_path == initial_snapshot
+        assert old_asmt.keep_meta == KeepMeta()
+        assert not old_asmt.new
 
-    # We should only keep one proposed full backup
-    ((backup_uuid, backup_asmt),) = list(source_asmt.backups.items())
-    assert backup_uuid == proposed_info.uuid
-    assert backup_asmt.keep_meta == KeepMeta(
-        reasons=Reasons.MostRecent, flags=Flags.New
-    )
-    assert backup_asmt.new
+        # We should only keep one proposed full backup
+        ((backup_uuid, backup_asmt),) = list(source_asmt.backups.items())
+        assert backup_uuid == proposed_info.uuid
+        assert backup_asmt.keep_meta == KeepMeta(
+            reasons=Reasons.MostRecent, flags=Flags.New
+        )
+        assert backup_asmt.new
 
-    actions = Actions()
-    assessment_to_actions(assessment, actions)
+        actions = Actions()
+        assessment_to_actions(assessment, actions)
 
-    (create_snapshot_intent,) = list(actions.iter_create_snapshot_intents())
-    assert create_snapshot_intent.source.peek() == source
-    assert snapshot_dir in create_snapshot_intent.path().parents
-    assert create_snapshot_intent.path().name.startswith(source.name)
-    (rename_snapshot_intent,) = list(actions.iter_rename_snapshot_intents())
-    assert rename_snapshot_intent.source.peek() == create_snapshot_intent.path.peek()
-    (create_backup_intent,) = list(actions.iter_create_backup_intents())
-    assert create_backup_intent.source.peek() == source
-    (delete_snapshot_intent,) = list(actions.iter_delete_snapshot_intents())
-    assert delete_snapshot_intent.path.peek() == initial_snapshot
+        (create_snapshot_intent,) = list(actions.iter_create_snapshot_intents())
+        assert create_snapshot_intent.source.peek() == source
+        assert snapshot_dir in create_snapshot_intent.path().parents
+        assert create_snapshot_intent.path().name.startswith(source.name)
+        (rename_snapshot_intent,) = list(actions.iter_rename_snapshot_intents())
+        assert (
+            rename_snapshot_intent.source.peek() == create_snapshot_intent.path.peek()
+        )
+        (create_backup_intent,) = list(actions.iter_create_backup_intents())
+        assert create_backup_intent.source.peek() == source
+        (delete_snapshot_intent,) = list(actions.iter_delete_snapshot_intents())
+        assert delete_snapshot_intent.path.peek() == initial_snapshot
 
-    actions.execute(s3, bucket)
+        actions.execute(s3, bucket)
+    else:
+        remote = Remote.create(name="test", s3=s3, bucket=bucket)
+        with (
+            Source.create(source) as source_,
+            SnapshotDir.create(snapshot_dir) as snapshot_dir_,
+        ):
+            assessment_ = planner_assess(
+                ConfigTuple(
+                    source=source_,
+                    snapshot_dir=snapshot_dir_,
+                    remote=remote,
+                    policy=Policy(),
+                    create_pipe=partial(filter_pipe, []),
+                )
+            )
+            actions_ = planner_assessment_to_actions(assessment_)
+            actions_.execute()
 
     (snapshot,) = list(snapshot_dir.iterdir())
     assert snapshot.name.startswith(source.name)
@@ -365,7 +479,7 @@ def test_delete_only_snapshot_because_proposed_would_be_newer(
 
 
 def test_ignore_read_write_snapshot(
-    btrfs_mountpoint: Path, s3: S3Client, bucket: str
+    btrfs_mountpoint: Path, s3: S3Client, bucket: str, impl: Impl
 ) -> None:
     # Create a subvolume
     source = btrfs_mountpoint / "source"
@@ -380,16 +494,34 @@ def test_ignore_read_write_snapshot(
     btrfsutil.create_snapshot(source, initial_snapshot)
     btrfsutil.sync(source)
 
-    assessment = assess(
-        snapshot_dir=snapshot_dir,
-        sources=(source,),
-        s3=s3,
-        bucket=bucket,
-        policy=Policy(),
-    )
-    actions = Actions()
-    assessment_to_actions(assessment, actions)
-    actions.execute(s3, bucket)
+    if impl == Impl.Assessor:
+        assessment = assess(
+            snapshot_dir=snapshot_dir,
+            sources=(source,),
+            s3=s3,
+            bucket=bucket,
+            policy=Policy(),
+        )
+        actions = Actions()
+        assessment_to_actions(assessment, actions)
+        actions.execute(s3, bucket)
+    else:
+        remote = Remote.create(name="test", s3=s3, bucket=bucket)
+        with (
+            Source.create(source) as source_,
+            SnapshotDir.create(snapshot_dir) as snapshot_dir_,
+        ):
+            assessment_ = planner_assess(
+                ConfigTuple(
+                    source=source_,
+                    snapshot_dir=snapshot_dir_,
+                    remote=remote,
+                    policy=Policy(),
+                    create_pipe=partial(filter_pipe, []),
+                )
+            )
+            actions_ = planner_assessment_to_actions(assessment_)
+            actions_.execute()
 
     (snap1, snap2) = sorted(snapshot_dir.iterdir(), key=lambda p: p == initial_snapshot)
     assert snap2 == initial_snapshot
@@ -411,7 +543,7 @@ def test_fail_if_snapshot_dir_not_on_btrfs(
 
 
 def test_ignore_snapshots_from_unrelated_sources(
-    btrfs_mountpoint: Path, s3: S3Client, bucket: str
+    btrfs_mountpoint: Path, s3: S3Client, bucket: str, impl: Impl
 ) -> None:
     # Create subvolumes
     source1 = btrfs_mountpoint / "source1"
@@ -429,16 +561,34 @@ def test_ignore_snapshots_from_unrelated_sources(
     btrfsutil.create_snapshot(source2, ignore_snapshot, read_only=True)
     btrfsutil.sync(btrfs_mountpoint)
 
-    assessment = assess(
-        snapshot_dir=snapshot_dir,
-        sources=(source1,),
-        s3=s3,
-        bucket=bucket,
-        policy=Policy(),
-    )
-    actions = Actions()
-    assessment_to_actions(assessment, actions)
-    actions.execute(s3, bucket)
+    if impl == Impl.Assessor:
+        assessment = assess(
+            snapshot_dir=snapshot_dir,
+            sources=(source1,),
+            s3=s3,
+            bucket=bucket,
+            policy=Policy(),
+        )
+        actions = Actions()
+        assessment_to_actions(assessment, actions)
+        actions.execute(s3, bucket)
+    else:
+        remote = Remote.create(name="test", s3=s3, bucket=bucket)
+        with (
+            Source.create(source1) as source_,
+            SnapshotDir.create(snapshot_dir) as snapshot_dir_,
+        ):
+            assessment_ = planner_assess(
+                ConfigTuple(
+                    source=source_,
+                    snapshot_dir=snapshot_dir_,
+                    remote=remote,
+                    policy=Policy(),
+                    create_pipe=partial(filter_pipe, []),
+                )
+            )
+            actions_ = planner_assessment_to_actions(assessment_)
+            actions_.execute()
 
     (snap1, snap2) = sorted(snapshot_dir.iterdir(), key=lambda p: p == ignore_snapshot)
     assert snap2 == ignore_snapshot
@@ -447,27 +597,45 @@ def test_ignore_snapshots_from_unrelated_sources(
 
 
 def test_ignore_unrelated_s3_objects(
-    btrfs_mountpoint: Path, s3: S3Client, bucket: str
+    btrfs_mountpoint: Path, s3: S3Client, bucket: str, impl: Impl
 ) -> None:
     key = "not-a-backup-name"
     s3.put_object(Bucket=bucket, Key=key, Body=b"dummy")
 
-    assessment = assess(
-        snapshot_dir=btrfs_mountpoint,
-        sources=(btrfs_mountpoint,),
-        s3=s3,
-        bucket=bucket,
-        policy=Policy(),
-    )
-    actions = Actions()
-    assessment_to_actions(assessment, actions)
-    actions.execute(s3, bucket)
+    if impl == Impl.Assessor:
+        assessment = assess(
+            snapshot_dir=btrfs_mountpoint,
+            sources=(btrfs_mountpoint,),
+            s3=s3,
+            bucket=bucket,
+            policy=Policy(),
+        )
+        actions = Actions()
+        assessment_to_actions(assessment, actions)
+        actions.execute(s3, bucket)
+    else:
+        remote = Remote.create(name="test", s3=s3, bucket=bucket)
+        with (
+            Source.create(btrfs_mountpoint) as source_,
+            SnapshotDir.create(btrfs_mountpoint) as snapshot_dir_,
+        ):
+            assessment_ = planner_assess(
+                ConfigTuple(
+                    source=source_,
+                    snapshot_dir=snapshot_dir_,
+                    remote=remote,
+                    policy=Policy(),
+                    create_pipe=partial(filter_pipe, []),
+                )
+            )
+            actions_ = planner_assessment_to_actions(assessment_)
+            actions_.execute()
 
     assert s3.get_object(Bucket=bucket, Key=key)["Body"].read() == b"dummy"
 
 
 def test_ignore_unrelated_backups(
-    btrfs_mountpoint: Path, s3: S3Client, bucket: str
+    btrfs_mountpoint: Path, s3: S3Client, bucket: str, impl: Impl
 ) -> None:
     info = BackupInfo(
         uuid=uuid4().bytes,
@@ -479,21 +647,41 @@ def test_ignore_unrelated_backups(
     key = f"base{''.join(info.get_path_suffixes())}"
     s3.put_object(Bucket=bucket, Key=key, Body=b"dummy")
 
-    assessment = assess(
-        snapshot_dir=btrfs_mountpoint,
-        sources=(btrfs_mountpoint,),
-        s3=s3,
-        bucket=bucket,
-        policy=Policy(),
-    )
-    actions = Actions()
-    assessment_to_actions(assessment, actions)
-    actions.execute(s3, bucket)
+    if impl == Impl.Assessor:
+        assessment = assess(
+            snapshot_dir=btrfs_mountpoint,
+            sources=(btrfs_mountpoint,),
+            s3=s3,
+            bucket=bucket,
+            policy=Policy(),
+        )
+        actions = Actions()
+        assessment_to_actions(assessment, actions)
+        actions.execute(s3, bucket)
+    else:
+        remote = Remote.create(name="test", s3=s3, bucket=bucket)
+        with (
+            Source.create(btrfs_mountpoint) as source_,
+            SnapshotDir.create(btrfs_mountpoint) as snapshot_dir_,
+        ):
+            assessment_ = planner_assess(
+                ConfigTuple(
+                    source=source_,
+                    snapshot_dir=snapshot_dir_,
+                    remote=remote,
+                    policy=Policy(),
+                    create_pipe=partial(filter_pipe, []),
+                )
+            )
+            actions_ = planner_assessment_to_actions(assessment_)
+            actions_.execute()
 
     assert s3.get_object(Bucket=bucket, Key=key)["Body"].read() == b"dummy"
 
 
-def test_delete_old_backups(btrfs_mountpoint: Path, s3: S3Client, bucket: str) -> None:
+def test_delete_old_backups(
+    btrfs_mountpoint: Path, s3: S3Client, bucket: str, impl: Impl
+) -> None:
     # Create subvolume
     source = btrfs_mountpoint / "source"
     btrfsutil.create_subvolume(source)
@@ -511,16 +699,34 @@ def test_delete_old_backups(btrfs_mountpoint: Path, s3: S3Client, bucket: str) -
     (source / "dummy-file").write_bytes(b"dummy")
     btrfsutil.sync(btrfs_mountpoint)
 
-    assessment = assess(
-        snapshot_dir=snapshot_dir,
-        sources=(source,),
-        s3=s3,
-        bucket=bucket,
-        policy=Policy(),
-    )
-    actions = Actions()
-    assessment_to_actions(assessment, actions)
-    actions.execute(s3, bucket)
+    if impl == Impl.Assessor:
+        assessment = assess(
+            snapshot_dir=snapshot_dir,
+            sources=(source,),
+            s3=s3,
+            bucket=bucket,
+            policy=Policy(),
+        )
+        actions = Actions()
+        assessment_to_actions(assessment, actions)
+        actions.execute(s3, bucket)
+    else:
+        remote = Remote.create(name="test", s3=s3, bucket=bucket)
+        with (
+            Source.create(source) as source_,
+            SnapshotDir.create(snapshot_dir) as snapshot_dir_,
+        ):
+            assessment_ = planner_assess(
+                ConfigTuple(
+                    source=source_,
+                    snapshot_dir=snapshot_dir_,
+                    remote=remote,
+                    policy=Policy(),
+                    create_pipe=partial(filter_pipe, []),
+                )
+            )
+            actions_ = planner_assessment_to_actions(assessment_)
+            actions_.execute()
 
     # Ensure dummy backup was deleted
     with pytest.raises(ClientError):
@@ -528,7 +734,7 @@ def test_delete_old_backups(btrfs_mountpoint: Path, s3: S3Client, bucket: str) -
 
 
 def test_second_run_is_a_no_op(
-    btrfs_mountpoint: Path, s3: S3Client, bucket: str
+    btrfs_mountpoint: Path, s3: S3Client, bucket: str, impl: Impl
 ) -> None:
     # Create subvolume
     source = btrfs_mountpoint / "source"
@@ -540,26 +746,63 @@ def test_second_run_is_a_no_op(
     (source / "dummy-file").write_bytes(b"dummy")
     btrfsutil.sync(btrfs_mountpoint)
 
-    assessment = assess(
-        snapshot_dir=snapshot_dir,
-        sources=(source,),
-        s3=s3,
-        bucket=bucket,
-        policy=Policy(),
-    )
-    actions = Actions()
-    assessment_to_actions(assessment, actions)
-    actions.execute(s3, bucket)
+    if impl == Impl.Assessor:
+        assessment = assess(
+            snapshot_dir=snapshot_dir,
+            sources=(source,),
+            s3=s3,
+            bucket=bucket,
+            policy=Policy(),
+        )
+        actions = Actions()
+        assessment_to_actions(assessment, actions)
+        actions.execute(s3, bucket)
 
-    # Second run
+        # Second run
 
-    assessment = assess(
-        snapshot_dir=snapshot_dir,
-        sources=(source,),
-        s3=s3,
-        bucket=bucket,
-        policy=Policy(),
-    )
-    actions = Actions()
-    assessment_to_actions(assessment, actions)
-    assert actions.empty()
+        assessment = assess(
+            snapshot_dir=snapshot_dir,
+            sources=(source,),
+            s3=s3,
+            bucket=bucket,
+            policy=Policy(),
+        )
+        actions = Actions()
+        assessment_to_actions(assessment, actions)
+        assert actions.empty()
+    else:
+        remote = Remote.create(name="test", s3=s3, bucket=bucket)
+        with (
+            Source.create(source) as source_,
+            SnapshotDir.create(snapshot_dir) as snapshot_dir_,
+        ):
+            assessment_ = planner_assess(
+                ConfigTuple(
+                    source=source_,
+                    snapshot_dir=snapshot_dir_,
+                    remote=remote,
+                    policy=Policy(),
+                    create_pipe=partial(filter_pipe, []),
+                )
+            )
+            actions_ = planner_assessment_to_actions(assessment_)
+            actions_.execute()
+
+        # Second run
+
+        remote = Remote.create(name="test", s3=s3, bucket=bucket)
+        with (
+            Source.create(source) as source_,
+            SnapshotDir.create(snapshot_dir) as snapshot_dir_,
+        ):
+            assessment_ = planner_assess(
+                ConfigTuple(
+                    source=source_,
+                    snapshot_dir=snapshot_dir_,
+                    remote=remote,
+                    policy=Policy(),
+                    create_pipe=partial(filter_pipe, []),
+                )
+            )
+            actions_ = planner_assessment_to_actions(assessment_)
+            assert not actions_.any_actions()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 # btrfs2s3 - maintains a tree of differential backups in object storage.
 #
-# Copyright (C) 2024 Steven Brudenell and other contributors.
+# Copyright (C) 2024-2025 Steven Brudenell and other contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+from datetime import timezone
 from io import StringIO
 import os
 from pathlib import Path
@@ -35,6 +36,7 @@ import pytest
 from rich.console import Console
 
 from btrfs2s3._internal.console import THEME
+from btrfs2s3._internal.util import use_tzinfo
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -184,3 +186,9 @@ def goldifyconsole(
     console = console_factory(file=file)
     yield console
     goldify(file.getvalue())
+
+
+@pytest.fixture(autouse=True)
+def _utc() -> Iterator[None]:
+    with use_tzinfo(timezone.utc):
+        yield

--- a/tests/planner/__init__.py
+++ b/tests/planner/__init__.py
@@ -1,0 +1,16 @@
+# btrfs2s3 - maintains a tree of differential backups in object storage.
+#
+# Copyright (C) 2025 Steven Brudenell and other contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/tests/planner/actions_test.py
+++ b/tests/planner/actions_test.py
@@ -1,0 +1,345 @@
+# btrfs2s3 - maintains a tree of differential backups in object storage.
+#
+# Copyright (C) 2025 Steven Brudenell and other contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from functools import partial
+from typing import TYPE_CHECKING
+
+import pytest
+
+from btrfs2s3._internal.btrfsioctl import create_snap
+from btrfs2s3._internal.btrfsioctl import create_subvol
+from btrfs2s3._internal.btrfsioctl import subvol_info
+from btrfs2s3._internal.piper import filter_pipe
+from btrfs2s3._internal.planner import Actions
+from btrfs2s3._internal.planner import AssessedBackup
+from btrfs2s3._internal.planner import AssessedSnapshot
+from btrfs2s3._internal.planner import Assessment
+from btrfs2s3._internal.planner import assessment_to_actions
+from btrfs2s3._internal.planner import BackupObject
+from btrfs2s3._internal.planner import DeleteBackup
+from btrfs2s3._internal.planner import DestroySnapshot
+from btrfs2s3._internal.planner import ObjectStat
+from btrfs2s3._internal.planner import Remote
+from btrfs2s3._internal.planner import RenameSnapshot
+from btrfs2s3._internal.planner import SnapshotDir
+from btrfs2s3._internal.planner import Source
+from btrfs2s3._internal.planner import UploadBackup
+from btrfs2s3._internal.resolver import Flags
+from btrfs2s3._internal.resolver import KeepMeta
+from btrfs2s3._internal.resolver import Reasons
+from btrfs2s3._internal.util import backup_of_snapshot
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from mypy_boto3_s3.client import S3Client
+
+    from tests.conftest import DownloadAndPipe
+
+
+@pytest.fixture
+def source1_path(btrfs_mountpoint: Path) -> Path:
+    path = btrfs_mountpoint / "source1"
+    create_subvol(path)
+    return path
+
+
+@pytest.fixture
+def snapshot_dir1_path(btrfs_mountpoint: Path) -> Path:
+    path = btrfs_mountpoint / "snapshot_dir1"
+    path.mkdir()
+    return path
+
+
+@pytest.fixture
+def remote1(s3: S3Client, bucket: str) -> Remote:
+    return Remote.create(name="test1", s3=s3, bucket=bucket)
+
+
+@pytest.fixture
+def stack() -> Iterator[ExitStack]:
+    with ExitStack() as stack:
+        yield stack
+
+
+noop_pipe = partial(filter_pipe, [])
+
+
+def test_noop_with_snapshot_and_backup(
+    source1_path: Path, snapshot_dir1_path: Path, remote1: Remote, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot_path, read_only=True)
+    info = subvol_info(snapshot_path)
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    # Rename the snapshot
+    snapshot_dir1.rename_snapshot(info.id, source1.get_snapshot_name(info))
+    stat = remote1.upload(
+        snapshot_dir=snapshot_dir1,
+        snapshot_id=info.id,
+        send_parent_id=None,
+        key=source1.get_backup_key(backup_of_snapshot(info)),
+        create_pipe=noop_pipe,
+    )
+
+    asmt = Assessment(
+        snapshots={
+            info.uuid: AssessedSnapshot(
+                source=source1,
+                snapshot_dir=snapshot_dir1,
+                info=info,
+                meta=KeepMeta(reasons=Reasons.MostRecent),
+            )
+        },
+        backups={
+            (remote1, info.uuid): AssessedBackup(
+                source=source1,
+                remote=remote1,
+                info=backup_of_snapshot(info),
+                stat=stat,
+                key=source1.get_backup_key(backup_of_snapshot(info)),
+                meta=KeepMeta(reasons=Reasons.MostRecent),
+                create_pipe=noop_pipe,
+            )
+        },
+    )
+
+    actions = assessment_to_actions(asmt)
+
+    assert actions == Actions(
+        rename_snapshots=[], upload_backups=[], destroy_snapshots=[], delete_backups=[]
+    )
+
+    actions.execute()
+
+
+def test_rename_snapshot(
+    source1_path: Path, snapshot_dir1_path: Path, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot_path, read_only=True)
+    info = subvol_info(snapshot_path)
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+
+    asmt = Assessment(
+        snapshots={
+            info.uuid: AssessedSnapshot(
+                source=source1,
+                snapshot_dir=snapshot_dir1,
+                info=info,
+                meta=KeepMeta(reasons=Reasons.MostRecent),
+            )
+        },
+        backups={},
+    )
+
+    actions = assessment_to_actions(asmt)
+
+    assert actions == Actions(
+        rename_snapshots=[
+            RenameSnapshot(
+                snapshot_dir=snapshot_dir1,
+                info=info,
+                target_name=source1.get_snapshot_name(info),
+            )
+        ],
+        upload_backups=[],
+        destroy_snapshots=[],
+        delete_backups=[],
+    )
+
+    actions.execute()
+
+    assert (
+        subvol_info(snapshot_dir1_path / source1.get_snapshot_name(info)).id == info.id
+    )
+
+
+def test_destroy_snapshot(
+    source1_path: Path, snapshot_dir1_path: Path, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot_path, read_only=True)
+    info = subvol_info(snapshot_path)
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+
+    asmt = Assessment(
+        snapshots={
+            info.uuid: AssessedSnapshot(
+                source=source1, snapshot_dir=snapshot_dir1, info=info, meta=KeepMeta()
+            )
+        },
+        backups={},
+    )
+    actions = assessment_to_actions(asmt)
+
+    assert actions == Actions(
+        rename_snapshots=[],
+        upload_backups=[],
+        destroy_snapshots=[DestroySnapshot(snapshot_dir=snapshot_dir1, info=info)],
+        delete_backups=[],
+    )
+
+    actions.execute()
+
+    assert list(snapshot_dir1_path.iterdir()) == []
+
+
+def test_upload_backup(
+    source1_path: Path,
+    snapshot_dir1_path: Path,
+    remote1: Remote,
+    stack: ExitStack,
+    download_and_pipe: DownloadAndPipe,
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot_path, read_only=True)
+    info = subvol_info(snapshot_path)
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    # Rename the snapshot
+    snapshot_dir1.rename_snapshot(info.id, source1.get_snapshot_name(info))
+
+    asmt = Assessment(
+        snapshots={
+            info.uuid: AssessedSnapshot(
+                source=source1,
+                snapshot_dir=snapshot_dir1,
+                info=info,
+                meta=KeepMeta(reasons=Reasons.MostRecent),
+            )
+        },
+        backups={
+            (remote1, info.uuid): AssessedBackup(
+                source=source1,
+                remote=remote1,
+                info=backup_of_snapshot(info),
+                stat=None,
+                key=source1.get_backup_key(backup_of_snapshot(info)),
+                meta=KeepMeta(flags=Flags.New, reasons=Reasons.MostRecent),
+                create_pipe=noop_pipe,
+            )
+        },
+    )
+
+    actions = assessment_to_actions(asmt)
+
+    assert actions == Actions(
+        rename_snapshots=[],
+        upload_backups=[
+            UploadBackup(
+                remote=remote1,
+                key=source1.get_backup_key(backup_of_snapshot(info)),
+                snapshot_dir=snapshot_dir1,
+                info=info,
+                send_parent=None,
+                create_pipe=noop_pipe,
+            )
+        ],
+        destroy_snapshots=[],
+        delete_backups=[],
+    )
+
+    actions.execute()
+
+    assert remote1.get_objects(source1) == {
+        info.uuid: BackupObject(
+            key=source1.get_backup_key(backup_of_snapshot(info)),
+            info=backup_of_snapshot(info),
+            stat=ObjectStat(),
+        )
+    }
+    download_and_pipe(
+        source1.get_backup_key(backup_of_snapshot(info)), ["btrfs", "receive", "--dump"]
+    )
+
+
+def test_delete_backup(
+    source1_path: Path, snapshot_dir1_path: Path, remote1: Remote, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot_path, read_only=True)
+    info = subvol_info(snapshot_path)
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    # Rename the snapshot
+    snapshot_dir1.rename_snapshot(info.id, source1.get_snapshot_name(info))
+    # Upload the backup
+    stat = remote1.upload(
+        snapshot_dir=snapshot_dir1,
+        snapshot_id=info.id,
+        send_parent_id=None,
+        key=source1.get_backup_key(backup_of_snapshot(info)),
+        create_pipe=noop_pipe,
+    )
+
+    asmt = Assessment(
+        snapshots={},
+        backups={
+            (remote1, info.uuid): AssessedBackup(
+                source=source1,
+                remote=remote1,
+                info=backup_of_snapshot(info),
+                stat=stat,
+                key=source1.get_backup_key(backup_of_snapshot(info)),
+                meta=KeepMeta(),
+                create_pipe=noop_pipe,
+            )
+        },
+    )
+
+    actions = assessment_to_actions(asmt)
+
+    assert actions == Actions(
+        rename_snapshots=[],
+        upload_backups=[],
+        destroy_snapshots=[],
+        delete_backups=[
+            DeleteBackup(
+                remote=remote1,
+                key=source1.get_backup_key(backup_of_snapshot(info)),
+                info=backup_of_snapshot(info),
+                stat=stat,
+            )
+        ],
+    )
+
+    actions.execute()
+
+    assert remote1.get_objects(source1) == {}

--- a/tests/planner/assess_test.py
+++ b/tests/planner/assess_test.py
@@ -1,0 +1,743 @@
+# btrfs2s3 - maintains a tree of differential backups in object storage.
+#
+# Copyright (C) 2025 Steven Brudenell and other contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from functools import partial
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from btrfs2s3._internal.btrfsioctl import create_snap
+from btrfs2s3._internal.btrfsioctl import create_subvol
+from btrfs2s3._internal.btrfsioctl import subvol_info
+from btrfs2s3._internal.piper import filter_pipe
+from btrfs2s3._internal.planner import assess
+from btrfs2s3._internal.planner import AssessedBackup
+from btrfs2s3._internal.planner import AssessedSnapshot
+from btrfs2s3._internal.planner import Assessment
+from btrfs2s3._internal.planner import ConfigTuple
+from btrfs2s3._internal.planner import destroy_new_snapshots
+from btrfs2s3._internal.planner import Remote
+from btrfs2s3._internal.planner import SnapshotDir
+from btrfs2s3._internal.planner import Source
+from btrfs2s3._internal.preservation import Params
+from btrfs2s3._internal.preservation import Policy
+from btrfs2s3._internal.resolver import Flags
+from btrfs2s3._internal.resolver import KeepMeta
+from btrfs2s3._internal.resolver import Reasons
+from btrfs2s3._internal.util import backup_of_snapshot
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from mypy_boto3_s3.client import S3Client
+
+
+@pytest.fixture
+def source1_path(btrfs_mountpoint: Path) -> Path:
+    path = btrfs_mountpoint / "source1"
+    create_subvol(path)
+    return path
+
+
+@pytest.fixture
+def source2_path(btrfs_mountpoint: Path) -> Path:
+    path = btrfs_mountpoint / "source2"
+    create_subvol(path)
+    return path
+
+
+@pytest.fixture
+def snapshot_dir1_path(btrfs_mountpoint: Path) -> Path:
+    path = btrfs_mountpoint / "snapshot_dir1"
+    path.mkdir()
+    return path
+
+
+@pytest.fixture
+def snapshot_dir2_path(btrfs_mountpoint: Path) -> Path:
+    path = btrfs_mountpoint / "snapshot_dir2"
+    path.mkdir()
+    return path
+
+
+@pytest.fixture
+def remote1(s3: S3Client, bucket: str) -> Remote:
+    return Remote.create(name="test1", s3=s3, bucket=bucket)
+
+
+@pytest.fixture
+def remote2(s3: S3Client) -> Remote:
+    s3.create_bucket(Bucket="test-bucket-2")
+    return Remote.create(name="test2", s3=s3, bucket="test-bucket-2")
+
+
+@pytest.fixture
+def stack() -> Iterator[ExitStack]:
+    with ExitStack() as stack:
+        yield stack
+
+
+noop_pipe = partial(filter_pipe, [])
+
+
+def test_one_snapshot(
+    source1_path: Path, snapshot_dir1_path: Path, remote1: Remote, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot_path, read_only=True)
+
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    asmt = assess(
+        ConfigTuple(
+            source=source1,
+            snapshot_dir=snapshot_dir1,
+            remote=remote1,
+            policy=Policy(),
+            create_pipe=noop_pipe,
+        )
+    )
+
+    info = subvol_info(snapshot_path)
+    assert asmt == Assessment(
+        snapshots={
+            info.uuid: AssessedSnapshot(
+                source=source1,
+                snapshot_dir=snapshot_dir1,
+                info=info,
+                meta=KeepMeta(reasons=Reasons.MostRecent),
+            )
+        },
+        backups={
+            (remote1, info.uuid): AssessedBackup(
+                source=source1,
+                remote=remote1,
+                info=backup_of_snapshot(info),
+                stat=None,
+                key=source1.get_backup_key(backup_of_snapshot(info)),
+                meta=KeepMeta(reasons=Reasons.MostRecent, flags=Flags.New),
+                create_pipe=noop_pipe,
+            )
+        },
+    )
+
+
+def test_create_snapshot_none_exist(
+    source1_path: Path, snapshot_dir1_path: Path, remote1: Remote, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    asmt = assess(
+        ConfigTuple(
+            source=source1,
+            snapshot_dir=snapshot_dir1,
+            remote=remote1,
+            policy=Policy(),
+            create_pipe=noop_pipe,
+        )
+    )
+
+    info = subvol_info(snapshot_dir1_path / source1.get_new_snapshot_name())
+    assert asmt == Assessment(
+        snapshots={
+            info.uuid: AssessedSnapshot(
+                source=source1,
+                snapshot_dir=snapshot_dir1,
+                info=info,
+                meta=KeepMeta(reasons=Reasons.MostRecent, flags=Flags.New),
+            )
+        },
+        backups={
+            (remote1, info.uuid): AssessedBackup(
+                source=source1,
+                remote=remote1,
+                info=backup_of_snapshot(info),
+                stat=None,
+                key=source1.get_backup_key(backup_of_snapshot(info)),
+                meta=KeepMeta(reasons=Reasons.MostRecent, flags=Flags.New),
+                create_pipe=noop_pipe,
+            )
+        },
+    )
+
+
+def test_create_snapshot_one_exists(
+    source1_path: Path, snapshot_dir1_path: Path, remote1: Remote, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot1_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot1_path, read_only=True)
+    info1 = subvol_info(snapshot1_path)
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy2")
+
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    asmt = assess(
+        ConfigTuple(
+            source=source1,
+            snapshot_dir=snapshot_dir1,
+            remote=remote1,
+            policy=Policy(),
+            create_pipe=noop_pipe,
+        )
+    )
+
+    info2 = subvol_info(snapshot_dir1_path / source1.get_new_snapshot_name())
+    assert asmt == Assessment(
+        snapshots={
+            info1.uuid: AssessedSnapshot(
+                source=source1, snapshot_dir=snapshot_dir1, info=info1, meta=KeepMeta()
+            ),
+            info2.uuid: AssessedSnapshot(
+                source=source1,
+                snapshot_dir=snapshot_dir1,
+                info=info2,
+                meta=KeepMeta(reasons=Reasons.MostRecent, flags=Flags.New),
+            ),
+        },
+        backups={
+            (remote1, info2.uuid): AssessedBackup(
+                source=source1,
+                remote=remote1,
+                info=backup_of_snapshot(info2),
+                stat=None,
+                key=source1.get_backup_key(backup_of_snapshot(info2)),
+                meta=KeepMeta(reasons=Reasons.MostRecent, flags=Flags.New),
+                create_pipe=noop_pipe,
+            )
+        },
+    )
+
+
+def test_create_snapshot_and_destroy_new(
+    source1_path: Path, snapshot_dir1_path: Path, remote1: Remote, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot1_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot1_path, read_only=True)
+    info1 = subvol_info(snapshot1_path)
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy2")
+
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    asmt = assess(
+        ConfigTuple(
+            source=source1,
+            snapshot_dir=snapshot_dir1,
+            remote=remote1,
+            policy=Policy(),
+            create_pipe=noop_pipe,
+        )
+    )
+
+    info2 = subvol_info(snapshot_dir1_path / source1.get_new_snapshot_name())
+    assert asmt == Assessment(
+        snapshots={
+            info1.uuid: AssessedSnapshot(
+                source=source1, snapshot_dir=snapshot_dir1, info=info1, meta=KeepMeta()
+            ),
+            info2.uuid: AssessedSnapshot(
+                source=source1,
+                snapshot_dir=snapshot_dir1,
+                info=info2,
+                meta=KeepMeta(reasons=Reasons.MostRecent, flags=Flags.New),
+            ),
+        },
+        backups={
+            (remote1, info2.uuid): AssessedBackup(
+                source=source1,
+                remote=remote1,
+                info=backup_of_snapshot(info2),
+                stat=None,
+                key=source1.get_backup_key(backup_of_snapshot(info2)),
+                meta=KeepMeta(reasons=Reasons.MostRecent, flags=Flags.New),
+                create_pipe=noop_pipe,
+            )
+        },
+    )
+
+    destroy_new_snapshots(asmt)
+    assert snapshot_dir1.get_snapshots(source1) == {info1.uuid: info1}
+
+
+def test_keep_existing_backup(
+    source1_path: Path, snapshot_dir1_path: Path, remote1: Remote, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot_path, read_only=True)
+    info = subvol_info(snapshot_path)
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    stat = remote1.upload(
+        snapshot_dir=snapshot_dir1,
+        snapshot_id=info.id,
+        send_parent_id=None,
+        key=source1.get_backup_key(backup_of_snapshot(info)),
+        create_pipe=noop_pipe,
+    )
+
+    asmt = assess(
+        ConfigTuple(
+            source=source1,
+            snapshot_dir=snapshot_dir1,
+            remote=remote1,
+            policy=Policy(),
+            create_pipe=noop_pipe,
+        )
+    )
+
+    assert asmt == Assessment(
+        snapshots={
+            info.uuid: AssessedSnapshot(
+                source=source1,
+                snapshot_dir=snapshot_dir1,
+                info=info,
+                meta=KeepMeta(reasons=Reasons.MostRecent),
+            )
+        },
+        backups={
+            (remote1, info.uuid): AssessedBackup(
+                source=source1,
+                remote=remote1,
+                info=backup_of_snapshot(info),
+                stat=stat,
+                key=source1.get_backup_key(backup_of_snapshot(info)),
+                meta=KeepMeta(reasons=Reasons.MostRecent),
+                create_pipe=noop_pipe,
+            )
+        },
+    )
+
+
+def test_backup_with_parent(
+    source1_path: Path, snapshot_dir1_path: Path, remote1: Remote, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot1_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot1_path, read_only=True)
+    # Modify the source again
+    (source1_path / "dummy-file").write_bytes(b"dummy2")
+    # Create a second snapshot
+    snapshot2_path = snapshot_dir1_path / "snapshot2"
+    create_snap(src=source1_path, dst=snapshot2_path, read_only=True)
+
+    # This isn't guaranteed to work at year boundaries. Can't think of a better
+    # way to do it right now.
+    now = time.time()
+    policy = Policy(now=now, params=Params(years=1))
+
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    asmt = assess(
+        ConfigTuple(
+            source=source1,
+            snapshot_dir=snapshot_dir1,
+            remote=remote1,
+            policy=policy,
+            create_pipe=noop_pipe,
+        )
+    )
+
+    expected_time_span = next(policy.iter_time_spans(now))
+    info1 = subvol_info(snapshot1_path)
+    info2 = subvol_info(snapshot2_path)
+    assert asmt == Assessment(
+        snapshots={
+            info1.uuid: AssessedSnapshot(
+                source=source1,
+                snapshot_dir=snapshot_dir1,
+                info=info1,
+                meta=KeepMeta(
+                    reasons=Reasons.Preserved, time_spans={expected_time_span}
+                ),
+            ),
+            info2.uuid: AssessedSnapshot(
+                source=source1,
+                snapshot_dir=snapshot_dir1,
+                info=info2,
+                meta=KeepMeta(reasons=Reasons.MostRecent),
+            ),
+        },
+        backups={
+            (remote1, info1.uuid): AssessedBackup(
+                source=source1,
+                remote=remote1,
+                info=backup_of_snapshot(info1),
+                stat=None,
+                key=source1.get_backup_key(backup_of_snapshot(info1)),
+                meta=KeepMeta(
+                    reasons=Reasons.Preserved,
+                    flags=Flags.New,
+                    time_spans={expected_time_span},
+                ),
+                create_pipe=noop_pipe,
+            ),
+            (remote1, info2.uuid): AssessedBackup(
+                source=source1,
+                remote=remote1,
+                info=backup_of_snapshot(info2, send_parent=info1),
+                stat=None,
+                key=source1.get_backup_key(
+                    backup_of_snapshot(info2, send_parent=info1)
+                ),
+                meta=KeepMeta(reasons=Reasons.MostRecent, flags=Flags.New),
+                create_pipe=noop_pipe,
+            ),
+        },
+    )
+
+
+def test_destroy_snapshot(
+    source1_path: Path, snapshot_dir1_path: Path, remote1: Remote, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot1_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot1_path, read_only=True)
+    # Modify the source again
+    (source1_path / "dummy-file").write_bytes(b"dummy2")
+    # Create a second snapshot
+    snapshot2_path = snapshot_dir1_path / "snapshot2"
+    create_snap(src=source1_path, dst=snapshot2_path, read_only=True)
+
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    asmt = assess(
+        ConfigTuple(
+            source=source1,
+            snapshot_dir=snapshot_dir1,
+            remote=remote1,
+            policy=Policy(),
+            create_pipe=noop_pipe,
+        )
+    )
+
+    info1 = subvol_info(snapshot1_path)
+    info2 = subvol_info(snapshot2_path)
+    assert asmt == Assessment(
+        snapshots={
+            info1.uuid: AssessedSnapshot(
+                source=source1, snapshot_dir=snapshot_dir1, info=info1, meta=KeepMeta()
+            ),
+            info2.uuid: AssessedSnapshot(
+                source=source1,
+                snapshot_dir=snapshot_dir1,
+                info=info2,
+                meta=KeepMeta(reasons=Reasons.MostRecent),
+            ),
+        },
+        backups={
+            (remote1, info2.uuid): AssessedBackup(
+                source=source1,
+                remote=remote1,
+                info=backup_of_snapshot(info2),
+                stat=None,
+                key=source1.get_backup_key(backup_of_snapshot(info2)),
+                meta=KeepMeta(reasons=Reasons.MostRecent, flags=Flags.New),
+                create_pipe=noop_pipe,
+            )
+        },
+    )
+
+
+def test_delete_backup(
+    source1_path: Path, snapshot_dir1_path: Path, remote1: Remote, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot1_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot1_path, read_only=True)
+    # Modify the source again
+    (source1_path / "dummy-file").write_bytes(b"dummy2")
+    # Create a second snapshot
+    snapshot2_path = snapshot_dir1_path / "snapshot2"
+    create_snap(src=source1_path, dst=snapshot2_path, read_only=True)
+    info1 = subvol_info(snapshot1_path)
+    info2 = subvol_info(snapshot2_path)
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    # Upload a backup of the initial snapshot
+    stat1 = remote1.upload(
+        snapshot_dir=snapshot_dir1,
+        snapshot_id=info1.id,
+        send_parent_id=None,
+        key=source1.get_backup_key(backup_of_snapshot(info1)),
+        create_pipe=noop_pipe,
+    )
+    asmt = assess(
+        ConfigTuple(
+            source=source1,
+            snapshot_dir=snapshot_dir1,
+            remote=remote1,
+            policy=Policy(),
+            create_pipe=noop_pipe,
+        )
+    )
+
+    assert asmt == Assessment(
+        snapshots={
+            info1.uuid: AssessedSnapshot(
+                source=source1, snapshot_dir=snapshot_dir1, info=info1, meta=KeepMeta()
+            ),
+            info2.uuid: AssessedSnapshot(
+                source=source1,
+                snapshot_dir=snapshot_dir1,
+                info=info2,
+                meta=KeepMeta(reasons=Reasons.MostRecent),
+            ),
+        },
+        backups={
+            (remote1, info1.uuid): AssessedBackup(
+                source=source1,
+                remote=remote1,
+                info=backup_of_snapshot(info1),
+                stat=stat1,
+                key=source1.get_backup_key(backup_of_snapshot(info1)),
+                meta=KeepMeta(),
+                create_pipe=noop_pipe,
+            ),
+            (remote1, info2.uuid): AssessedBackup(
+                source=source1,
+                remote=remote1,
+                info=backup_of_snapshot(info2),
+                stat=None,
+                key=source1.get_backup_key(backup_of_snapshot(info2)),
+                meta=KeepMeta(reasons=Reasons.MostRecent, flags=Flags.New),
+                create_pipe=noop_pipe,
+            ),
+        },
+    )
+
+
+def test_one_source_two_remotes(
+    source1_path: Path,
+    snapshot_dir1_path: Path,
+    remote1: Remote,
+    remote2: Remote,
+    stack: ExitStack,
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot_path = snapshot_dir1_path / "snapshot"
+    create_snap(src=source1_path, dst=snapshot_path, read_only=True)
+    now = time.time()
+    policy1 = Policy(now=now, params=Params(months=1))
+    policy2 = Policy(now=now, params=Params(years=1))
+
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    asmt = assess(
+        ConfigTuple(
+            source=source1,
+            snapshot_dir=snapshot_dir1,
+            remote=remote1,
+            policy=policy1,
+            create_pipe=noop_pipe,
+        ),
+        ConfigTuple(
+            source=source1,
+            snapshot_dir=snapshot_dir1,
+            remote=remote2,
+            policy=policy2,
+            create_pipe=noop_pipe,
+        ),
+    )
+
+    info = subvol_info(snapshot_path)
+    policy1_expected_time_span = next(policy1.iter_time_spans(now))
+    policy2_expected_time_span = next(policy2.iter_time_spans(now))
+    assert asmt == Assessment(
+        snapshots={
+            info.uuid: AssessedSnapshot(
+                source=source1,
+                snapshot_dir=snapshot_dir1,
+                info=info,
+                meta=KeepMeta(
+                    reasons=Reasons.MostRecent | Reasons.Preserved,
+                    time_spans={policy1_expected_time_span, policy2_expected_time_span},
+                ),
+            )
+        },
+        backups={
+            (remote1, info.uuid): AssessedBackup(
+                source=source1,
+                remote=remote1,
+                info=backup_of_snapshot(info),
+                stat=None,
+                key=source1.get_backup_key(backup_of_snapshot(info)),
+                meta=KeepMeta(
+                    reasons=Reasons.MostRecent | Reasons.Preserved,
+                    flags=Flags.New,
+                    time_spans={policy1_expected_time_span},
+                ),
+                create_pipe=noop_pipe,
+            ),
+            (remote2, info.uuid): AssessedBackup(
+                source=source1,
+                remote=remote2,
+                info=backup_of_snapshot(info),
+                stat=None,
+                key=source1.get_backup_key(backup_of_snapshot(info)),
+                meta=KeepMeta(
+                    reasons=Reasons.MostRecent | Reasons.Preserved,
+                    flags=Flags.New,
+                    time_spans={policy2_expected_time_span},
+                ),
+                create_pipe=noop_pipe,
+            ),
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "shared_snapshot_dir",
+    [True, False],
+    ids=["shared_snapshot_dir", "separate_snapshot_dirs"],
+)
+@pytest.mark.parametrize(
+    "shared_remote", [True, False], ids=["shared_remote", "separate_remotes"]
+)
+def test_two_sources(
+    source1_path: Path,
+    source2_path: Path,
+    snapshot_dir1_path: Path,
+    snapshot_dir2_path: Path,
+    remote1: Remote,
+    remote2: Remote,
+    stack: ExitStack,
+    shared_snapshot_dir: bool,  # noqa: FBT001
+    shared_remote: bool,  # noqa: FBT001
+) -> None:
+    if shared_snapshot_dir:
+        snapshot_dir2_path = snapshot_dir1_path
+    if shared_remote:
+        remote2 = remote1
+    # Modify some data in the sources
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    (source2_path / "dummy-file").write_bytes(b"dummy")
+    # Create snapshots
+    snapshot1_path = snapshot_dir1_path / "snapshot1"
+    snapshot2_path = snapshot_dir2_path / "snapshot2"
+    create_snap(src=source1_path, dst=snapshot1_path, read_only=True)
+    create_snap(src=source2_path, dst=snapshot2_path, read_only=True)
+    now = time.time()
+    policy1 = Policy(now=now, params=Params(months=1))
+    policy2 = Policy(now=now, params=Params(years=1))
+
+    source1 = stack.enter_context(Source.create(source1_path))
+    source2 = stack.enter_context(Source.create(source2_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    if shared_snapshot_dir:
+        snapshot_dir2 = snapshot_dir1
+    else:
+        snapshot_dir2 = stack.enter_context(SnapshotDir.create(snapshot_dir2_path))
+    asmt = assess(
+        ConfigTuple(
+            source=source1,
+            snapshot_dir=snapshot_dir1,
+            remote=remote1,
+            policy=policy1,
+            create_pipe=noop_pipe,
+        ),
+        ConfigTuple(
+            source=source2,
+            snapshot_dir=snapshot_dir2,
+            remote=remote2,
+            policy=policy2,
+            create_pipe=noop_pipe,
+        ),
+    )
+
+    info1 = subvol_info(snapshot1_path)
+    info2 = subvol_info(snapshot2_path)
+    policy1_expected_time_span = next(policy1.iter_time_spans(now))
+    policy2_expected_time_span = next(policy2.iter_time_spans(now))
+    assert asmt == Assessment(
+        snapshots={
+            info1.uuid: AssessedSnapshot(
+                source=source1,
+                snapshot_dir=snapshot_dir1,
+                info=info1,
+                meta=KeepMeta(
+                    reasons=Reasons.MostRecent | Reasons.Preserved,
+                    time_spans={policy1_expected_time_span},
+                ),
+            ),
+            info2.uuid: AssessedSnapshot(
+                source=source2,
+                snapshot_dir=snapshot_dir2,
+                info=info2,
+                meta=KeepMeta(
+                    reasons=Reasons.MostRecent | Reasons.Preserved,
+                    time_spans={policy2_expected_time_span},
+                ),
+            ),
+        },
+        backups={
+            (remote1, info1.uuid): AssessedBackup(
+                source=source1,
+                remote=remote1,
+                info=backup_of_snapshot(info1),
+                stat=None,
+                key=source1.get_backup_key(backup_of_snapshot(info1)),
+                meta=KeepMeta(
+                    reasons=Reasons.MostRecent | Reasons.Preserved,
+                    flags=Flags.New,
+                    time_spans={policy1_expected_time_span},
+                ),
+                create_pipe=noop_pipe,
+            ),
+            (remote2, info2.uuid): AssessedBackup(
+                source=source2,
+                remote=remote2,
+                info=backup_of_snapshot(info2),
+                stat=None,
+                key=source2.get_backup_key(backup_of_snapshot(info2)),
+                meta=KeepMeta(
+                    reasons=Reasons.MostRecent | Reasons.Preserved,
+                    flags=Flags.New,
+                    time_spans={policy2_expected_time_span},
+                ),
+                create_pipe=noop_pipe,
+            ),
+        },
+    )

--- a/tests/planner/assess_with_actions_integration_test.py
+++ b/tests/planner/assess_with_actions_integration_test.py
@@ -1,0 +1,372 @@
+# btrfs2s3 - maintains a tree of differential backups in object storage.
+#
+# Copyright (C) 2025 Steven Brudenell and other contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from functools import partial
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from btrfs2s3._internal.btrfsioctl import create_snap
+from btrfs2s3._internal.btrfsioctl import create_subvol
+from btrfs2s3._internal.btrfsioctl import subvol_info
+from btrfs2s3._internal.piper import filter_pipe
+from btrfs2s3._internal.planner import Actions
+from btrfs2s3._internal.planner import assess
+from btrfs2s3._internal.planner import assessment_to_actions
+from btrfs2s3._internal.planner import ConfigTuple
+from btrfs2s3._internal.planner import DeleteBackup
+from btrfs2s3._internal.planner import DestroySnapshot
+from btrfs2s3._internal.planner import Remote
+from btrfs2s3._internal.planner import RenameSnapshot
+from btrfs2s3._internal.planner import SnapshotDir
+from btrfs2s3._internal.planner import Source
+from btrfs2s3._internal.planner import UploadBackup
+from btrfs2s3._internal.preservation import Params
+from btrfs2s3._internal.preservation import Policy
+from btrfs2s3._internal.util import backup_of_snapshot
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from mypy_boto3_s3.client import S3Client
+
+
+@pytest.fixture
+def source1_path(btrfs_mountpoint: Path) -> Path:
+    path = btrfs_mountpoint / "source1"
+    create_subvol(path)
+    return path
+
+
+@pytest.fixture
+def snapshot_dir1_path(btrfs_mountpoint: Path) -> Path:
+    path = btrfs_mountpoint / "snapshot_dir1"
+    path.mkdir()
+    return path
+
+
+@pytest.fixture
+def remote1(s3: S3Client, bucket: str) -> Remote:
+    return Remote.create(name="test1", s3=s3, bucket=bucket)
+
+
+@pytest.fixture
+def stack() -> Iterator[ExitStack]:
+    with ExitStack() as stack:
+        yield stack
+
+
+noop_pipe = partial(filter_pipe, [])
+
+
+def test_noop(
+    source1_path: Path, snapshot_dir1_path: Path, remote1: Remote, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot_path, read_only=True)
+    info = subvol_info(snapshot_path)
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    # Rename the snapshot
+    snapshot_dir1.rename_snapshot(info.id, source1.get_snapshot_name(info))
+    # Upload the backup
+    remote1.upload(
+        snapshot_dir=snapshot_dir1,
+        snapshot_id=info.id,
+        send_parent_id=None,
+        key=source1.get_backup_key(backup_of_snapshot(info)),
+        create_pipe=noop_pipe,
+    )
+
+    asmt = assess(
+        ConfigTuple(
+            source=source1,
+            snapshot_dir=snapshot_dir1,
+            remote=remote1,
+            policy=Policy(),
+            create_pipe=noop_pipe,
+        )
+    )
+    actions = assessment_to_actions(asmt)
+    assert actions == Actions(
+        rename_snapshots=[], upload_backups=[], destroy_snapshots=[], delete_backups=[]
+    )
+
+
+def test_rename_snapshot(
+    source1_path: Path, snapshot_dir1_path: Path, remote1: Remote, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot_path, read_only=True)
+    info = subvol_info(snapshot_path)
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    # Upload the backup
+    remote1.upload(
+        snapshot_dir=snapshot_dir1,
+        snapshot_id=info.id,
+        send_parent_id=None,
+        key=source1.get_backup_key(backup_of_snapshot(info)),
+        create_pipe=noop_pipe,
+    )
+
+    asmt = assess(
+        ConfigTuple(
+            source=source1,
+            snapshot_dir=snapshot_dir1,
+            remote=remote1,
+            policy=Policy(),
+            create_pipe=noop_pipe,
+        )
+    )
+    actions = assessment_to_actions(asmt)
+    assert actions == Actions(
+        rename_snapshots=[
+            RenameSnapshot(
+                snapshot_dir=snapshot_dir1,
+                info=info,
+                target_name=source1.get_snapshot_name(info),
+            )
+        ],
+        upload_backups=[],
+        destroy_snapshots=[],
+        delete_backups=[],
+    )
+
+
+def test_upload_backup(
+    source1_path: Path, snapshot_dir1_path: Path, remote1: Remote, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot_path, read_only=True)
+    info = subvol_info(snapshot_path)
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    # Rename the snapshot
+    snapshot_dir1.rename_snapshot(info.id, source1.get_snapshot_name(info))
+
+    asmt = assess(
+        ConfigTuple(
+            source=source1,
+            snapshot_dir=snapshot_dir1,
+            remote=remote1,
+            policy=Policy(),
+            create_pipe=noop_pipe,
+        )
+    )
+    actions = assessment_to_actions(asmt)
+    assert actions == Actions(
+        rename_snapshots=[],
+        upload_backups=[
+            UploadBackup(
+                remote=remote1,
+                key=source1.get_backup_key(backup_of_snapshot(info)),
+                snapshot_dir=snapshot_dir1,
+                info=info,
+                send_parent=None,
+                create_pipe=noop_pipe,
+            )
+        ],
+        destroy_snapshots=[],
+        delete_backups=[],
+    )
+
+
+def test_upload_backup_with_parent(
+    source1_path: Path, snapshot_dir1_path: Path, remote1: Remote, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot1_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot1_path, read_only=True)
+    # Modify the source again
+    (source1_path / "dummy-file").write_bytes(b"dummy2")
+    # Create a second snapshot
+    snapshot2_path = snapshot_dir1_path / "snapshot2"
+    create_snap(src=source1_path, dst=snapshot2_path, read_only=True)
+    info1 = subvol_info(snapshot1_path)
+    info2 = subvol_info(snapshot2_path)
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    # Rename the snapshots
+    snapshot_dir1.rename_snapshot(info1.id, source1.get_snapshot_name(info1))
+    snapshot_dir1.rename_snapshot(info2.id, source1.get_snapshot_name(info2))
+    # Upload a backup of the first snapshot
+    remote1.upload(
+        snapshot_dir=snapshot_dir1,
+        snapshot_id=info1.id,
+        send_parent_id=None,
+        key=source1.get_backup_key(backup_of_snapshot(info1)),
+        create_pipe=noop_pipe,
+    )
+
+    # This isn't guaranteed to work at year boundaries. Can't think of a better
+    # way to do it right now.
+    now = time.time()
+    policy = Policy(now=now, params=Params(years=1))
+
+    asmt = assess(
+        ConfigTuple(
+            source=source1,
+            snapshot_dir=snapshot_dir1,
+            remote=remote1,
+            policy=policy,
+            create_pipe=noop_pipe,
+        )
+    )
+    actions = assessment_to_actions(asmt)
+    assert actions == Actions(
+        rename_snapshots=[],
+        upload_backups=[
+            UploadBackup(
+                remote=remote1,
+                key=source1.get_backup_key(
+                    backup_of_snapshot(info2, send_parent=info1)
+                ),
+                snapshot_dir=snapshot_dir1,
+                info=info2,
+                send_parent=info1,
+                create_pipe=noop_pipe,
+            )
+        ],
+        destroy_snapshots=[],
+        delete_backups=[],
+    )
+
+
+def test_delete_snapshot(
+    source1_path: Path, snapshot_dir1_path: Path, remote1: Remote, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot1_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot1_path, read_only=True)
+    # Modify the source again
+    (source1_path / "dummy-file").write_bytes(b"dummy2")
+    # Create a second snapshot
+    snapshot2_path = snapshot_dir1_path / "snapshot2"
+    create_snap(src=source1_path, dst=snapshot2_path, read_only=True)
+    info1 = subvol_info(snapshot1_path)
+    info2 = subvol_info(snapshot2_path)
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    # Rename the snapshots
+    snapshot_dir1.rename_snapshot(info1.id, source1.get_snapshot_name(info1))
+    snapshot_dir1.rename_snapshot(info2.id, source1.get_snapshot_name(info2))
+    # Upload a backup of the second snapshot
+    remote1.upload(
+        snapshot_dir=snapshot_dir1,
+        snapshot_id=info2.id,
+        send_parent_id=None,
+        key=source1.get_backup_key(backup_of_snapshot(info2)),
+        create_pipe=noop_pipe,
+    )
+
+    asmt = assess(
+        ConfigTuple(
+            source=source1,
+            snapshot_dir=snapshot_dir1,
+            remote=remote1,
+            policy=Policy(),
+            create_pipe=noop_pipe,
+        )
+    )
+    actions = assessment_to_actions(asmt)
+    assert actions == Actions(
+        rename_snapshots=[],
+        upload_backups=[],
+        destroy_snapshots=[DestroySnapshot(snapshot_dir=snapshot_dir1, info=info1)],
+        delete_backups=[],
+    )
+
+
+def test_delete_backup(
+    source1_path: Path, snapshot_dir1_path: Path, remote1: Remote, stack: ExitStack
+) -> None:
+    # Modify some data in the source
+    (source1_path / "dummy-file").write_bytes(b"dummy")
+    # Create an initial snapshot
+    snapshot1_path = snapshot_dir1_path / "snapshot1"
+    create_snap(src=source1_path, dst=snapshot1_path, read_only=True)
+    # Modify the source again
+    (source1_path / "dummy-file").write_bytes(b"dummy2")
+    # Create a second snapshot
+    snapshot2_path = snapshot_dir1_path / "snapshot2"
+    create_snap(src=source1_path, dst=snapshot2_path, read_only=True)
+    info1 = subvol_info(snapshot1_path)
+    info2 = subvol_info(snapshot2_path)
+    source1 = stack.enter_context(Source.create(source1_path))
+    snapshot_dir1 = stack.enter_context(SnapshotDir.create(snapshot_dir1_path))
+    # Rename the second snapshot
+    snapshot_dir1.rename_snapshot(info2.id, source1.get_snapshot_name(info2))
+    # Upload a backup of both snapshots
+    stat1 = remote1.upload(
+        snapshot_dir=snapshot_dir1,
+        snapshot_id=info1.id,
+        send_parent_id=None,
+        key=source1.get_backup_key(backup_of_snapshot(info1)),
+        create_pipe=noop_pipe,
+    )
+    remote1.upload(
+        snapshot_dir=snapshot_dir1,
+        snapshot_id=info2.id,
+        send_parent_id=None,
+        key=source1.get_backup_key(backup_of_snapshot(info2)),
+        create_pipe=noop_pipe,
+    )
+    # Delete the first snapshot
+    snapshot_dir1.destroy_snapshot(info1.id)
+
+    asmt = assess(
+        ConfigTuple(
+            source=source1,
+            snapshot_dir=snapshot_dir1,
+            remote=remote1,
+            policy=Policy(),
+            create_pipe=noop_pipe,
+        )
+    )
+    actions = assessment_to_actions(asmt)
+    assert actions == Actions(
+        rename_snapshots=[],
+        upload_backups=[],
+        destroy_snapshots=[],
+        delete_backups=[
+            DeleteBackup(
+                remote=remote1,
+                key=source1.get_backup_key(backup_of_snapshot(info1)),
+                info=backup_of_snapshot(info1),
+                stat=stat1,
+            )
+        ],
+    )

--- a/tests/planner/remote_test.py
+++ b/tests/planner/remote_test.py
@@ -1,0 +1,194 @@
+# btrfs2s3 - maintains a tree of differential backups in object storage.
+#
+# Copyright (C) 2025 Steven Brudenell and other contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from functools import partial
+from typing import TYPE_CHECKING
+
+from botocore.exceptions import ClientError
+from botocore.exceptions import ParamValidationError
+import pytest
+
+from btrfs2s3._internal.backups import BackupInfo
+from btrfs2s3._internal.btrfsioctl import create_snap
+from btrfs2s3._internal.btrfsioctl import create_subvol
+from btrfs2s3._internal.btrfsioctl import subvol_info
+from btrfs2s3._internal.piper import filter_pipe
+from btrfs2s3._internal.planner import BackupObject
+from btrfs2s3._internal.planner import ObjectStat
+from btrfs2s3._internal.planner import Remote
+from btrfs2s3._internal.planner import SnapshotDir
+from btrfs2s3._internal.planner import Source
+from btrfs2s3._internal.util import backup_of_snapshot
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mypy_boto3_s3.client import S3Client
+
+    from tests.conftest import DownloadAndPipe
+
+noop_pipe = partial(filter_pipe, [])
+
+
+def test_properties(s3: S3Client, bucket: str) -> None:
+    remote = Remote.create(name="test", s3=s3, bucket=bucket)
+
+    assert remote.name == "test"
+    assert remote.s3 == s3
+    assert remote.bucket == bucket
+
+
+def test_get_objects(btrfs_mountpoint: Path, s3: S3Client, bucket: str) -> None:
+    source_path = btrfs_mountpoint / "source"
+    create_subvol(source_path)
+    source_info = subvol_info(source_path)
+    unrelated_source_path = btrfs_mountpoint / "unrelated"
+    create_subvol(unrelated_source_path)
+    snapshot_dir_path = btrfs_mountpoint / "snapshots"
+    snapshot_dir_path.mkdir()
+    snap_path = snapshot_dir_path / "snapshot"
+    create_snap(src=source_path, dst=snap_path, read_only=True)
+    snap_info = subvol_info(snap_path)
+    info = BackupInfo(
+        uuid=snap_info.uuid,
+        parent_uuid=source_info.uuid,
+        send_parent_uuid=None,
+        ctransid=1,
+        ctime=123.0,
+    )
+    key = f"test{''.join(info.get_path_suffixes())}"
+    s3.put_object(Bucket=bucket, Key=key, Body=b"dummy")
+
+    remote = Remote.create(name="test", s3=s3, bucket=bucket)
+
+    with Source.create(source_path) as source:
+        assert remote.get_objects(source) == {
+            info.uuid: BackupObject(
+                key=key, info=info, stat=ObjectStat(size=5, storage_class="STANDARD")
+            )
+        }
+    with Source.create(unrelated_source_path) as unrelated_source:
+        assert remote.get_objects(unrelated_source) == {}
+
+
+def test_upload(
+    btrfs_mountpoint: Path,
+    s3: S3Client,
+    bucket: str,
+    download_and_pipe: DownloadAndPipe,
+) -> None:
+    snapshot_dir_path = btrfs_mountpoint / "snapshots"
+    snapshot_dir_path.mkdir()
+    source_path = btrfs_mountpoint / "source"
+    create_subvol(source_path)
+    snap_path = snapshot_dir_path / "snapshot"
+    create_snap(src=source_path, dst=snap_path, read_only=True)
+    snap_info = subvol_info(snap_path)
+    backup_info = backup_of_snapshot(snap_info)
+    key = f"test{''.join(backup_info.get_path_suffixes())}"
+    remote = Remote.create(name="test", s3=s3, bucket=bucket)
+
+    with SnapshotDir.create(snapshot_dir_path) as snapshot_dir:
+        stat = remote.upload(
+            snapshot_dir=snapshot_dir,
+            snapshot_id=snap_info.id,
+            send_parent_id=None,
+            key=key,
+            create_pipe=noop_pipe,
+        )
+
+    assert stat == ObjectStat()
+    download_and_pipe(key, ["btrfs", "receive", "--dump"])
+
+    with Source.create(source_path) as source:
+        assert remote.get_objects(source) == {
+            snap_info.uuid: BackupObject(key=key, info=backup_info, stat=ObjectStat())
+        }
+
+
+def test_upload_send_fails(btrfs_mountpoint: Path, s3: S3Client, bucket: str) -> None:
+    snapshot_dir_path = btrfs_mountpoint / "snapshots"
+    snapshot_dir_path.mkdir()
+    remote = Remote.create(name="test", s3=s3, bucket=bucket)
+
+    with SnapshotDir.create(snapshot_dir_path) as snapshot_dir:
+        with pytest.raises(KeyError, match="-123"):
+            remote.upload(
+                snapshot_dir=snapshot_dir,
+                snapshot_id=-123,
+                send_parent_id=None,
+                key="test-key",
+                create_pipe=noop_pipe,
+            )
+
+    # Ensure dummy backup was deleted
+    with pytest.raises(ClientError):
+        s3.head_object(Bucket=bucket, Key="test-key")
+
+
+def test_upload_put_object_fails(
+    btrfs_mountpoint: Path, s3: S3Client, bucket: str
+) -> None:
+    snapshot_dir_path = btrfs_mountpoint / "snapshots"
+    snapshot_dir_path.mkdir()
+    source_path = btrfs_mountpoint / "source"
+    create_subvol(source_path)
+    snap_path = snapshot_dir_path / "snapshot"
+    create_snap(src=source_path, dst=snap_path, read_only=True)
+    snap_info = subvol_info(snap_path)
+    remote = Remote.create(name="test", s3=s3, bucket=bucket)
+
+    with SnapshotDir.create(snapshot_dir_path) as snapshot_dir:
+        with pytest.raises(ParamValidationError):
+            remote.upload(
+                snapshot_dir=snapshot_dir,
+                snapshot_id=snap_info.id,
+                send_parent_id=None,
+                key="",
+                create_pipe=noop_pipe,
+            )
+
+
+def test_delete(btrfs_mountpoint: Path, s3: S3Client, bucket: str) -> None:
+    snapshot_dir_path = btrfs_mountpoint / "snapshots"
+    snapshot_dir_path.mkdir()
+    source_path = btrfs_mountpoint / "source"
+    create_subvol(source_path)
+    snap_path = snapshot_dir_path / "snapshot"
+    create_snap(src=source_path, dst=snap_path, read_only=True)
+    snap_info = subvol_info(snap_path)
+    backup_info = backup_of_snapshot(snap_info)
+    key = f"test{''.join(backup_info.get_path_suffixes())}"
+    remote = Remote.create(name="test", s3=s3, bucket=bucket)
+
+    with SnapshotDir.create(snapshot_dir_path) as snapshot_dir:
+        remote.upload(
+            snapshot_dir=snapshot_dir,
+            snapshot_id=snap_info.id,
+            send_parent_id=None,
+            key=key,
+            create_pipe=noop_pipe,
+        )
+
+    remote.delete(key)
+
+    with Source.create(source_path) as source:
+        assert remote.get_objects(source) == {}
+    with pytest.raises(ClientError):
+        s3.head_object(Bucket=bucket, Key=key)

--- a/tests/planner/snapshot_dir_test.py
+++ b/tests/planner/snapshot_dir_test.py
@@ -1,0 +1,269 @@
+# btrfs2s3 - maintains a tree of differential backups in object storage.
+#
+# Copyright (C) 2025 Steven Brudenell and other contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from errno import ENOTTY
+import os
+from subprocess import check_call
+from tempfile import TemporaryFile
+from typing import TYPE_CHECKING
+
+import pytest
+
+from btrfs2s3._internal.btrfsioctl import create_snap
+from btrfs2s3._internal.btrfsioctl import create_subvol
+from btrfs2s3._internal.btrfsioctl import subvol_info
+from btrfs2s3._internal.planner import SnapshotDir
+from btrfs2s3._internal.planner import Source
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_context_manager(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "snapshots"
+    path.mkdir()
+
+    with SnapshotDir.create(path):
+        pass
+
+
+def test_close(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "snapshots"
+    path.mkdir()
+
+    snapshot_dir = SnapshotDir.create(path)
+    snapshot_dir.close()
+
+
+def test_empty(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "snapshots"
+    path.mkdir()
+
+    with SnapshotDir.create(path):
+        pass
+
+
+def test_properties(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "snapshots"
+    path.mkdir()
+
+    with SnapshotDir.create(path) as snapshot_dir:
+        assert snapshot_dir.path == path
+
+
+def test_path_does_not_exist(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "snapshots"
+
+    with pytest.raises(FileNotFoundError):
+        SnapshotDir.create(path)
+
+
+def test_not_a_btrfs_directory(ext4_mountpoint: Path) -> None:
+    with pytest.raises(OSError, match="Inappropriate ioctl for device") as exc_info:
+        SnapshotDir.create(ext4_mountpoint)
+    assert exc_info.value.errno == ENOTTY
+
+
+def test_get_name(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "snapshots"
+    path.mkdir()
+    source_path = btrfs_mountpoint / "source"
+    create_subvol(source_path)
+    snap_path = path / "snapshot"
+    create_snap(src=source_path, dst=snap_path, read_only=True)
+    snap_info = subvol_info(snap_path)
+
+    with SnapshotDir.create(path) as snapshot_dir:
+        assert snapshot_dir.get_name(snap_info.id) == "snapshot"
+
+
+def test_get_path(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "snapshots"
+    path.mkdir()
+    source_path = btrfs_mountpoint / "source"
+    create_subvol(source_path)
+    snap_path = path / "snapshot"
+    create_snap(src=source_path, dst=snap_path, read_only=True)
+    snap_info = subvol_info(snap_path)
+
+    with SnapshotDir.create(path) as snapshot_dir:
+        assert snapshot_dir.get_path(snap_info.id) == snap_path
+
+
+def test_get_snapshots(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "snapshots"
+    path.mkdir()
+    source_path = btrfs_mountpoint / "source"
+    create_subvol(source_path)
+    snap_path = path / "snapshot"
+    create_snap(src=source_path, dst=snap_path, read_only=True)
+    snap_info = subvol_info(snap_path)
+    unrelated_source_path = path / "unrelated"
+    create_subvol(unrelated_source_path)
+
+    with SnapshotDir.create(path) as snapshot_dir:
+        with Source.create(source_path) as source:
+            assert snapshot_dir.get_snapshots(source) == {snap_info.uuid: snap_info}
+        with Source.create(unrelated_source_path) as unrelated_source:
+            assert snapshot_dir.get_snapshots(unrelated_source) == {}
+
+
+def test_ignore_read_write_snapshots(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "snapshots"
+    path.mkdir()
+    source_path = btrfs_mountpoint / "source"
+    create_subvol(source_path)
+    read_write_snap_path = path / "read-write-snapshot"
+    create_snap(src=source_path, dst=read_write_snap_path)
+    read_only_snap_path = path / "read-only-snapshot"
+    create_snap(src=source_path, dst=read_only_snap_path, read_only=True)
+    read_only_snap_info = subvol_info(read_only_snap_path)
+
+    with SnapshotDir.create(path) as snapshot_dir:
+        with Source.create(source_path) as source:
+            assert snapshot_dir.get_snapshots(source) == {
+                read_only_snap_info.uuid: read_only_snap_info
+            }
+
+
+def test_ignore_nested_snapshots(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "snapshots"
+    path.mkdir()
+    source_path = btrfs_mountpoint / "source"
+    create_subvol(source_path)
+    snap_path = path / "snapshot"
+    create_snap(src=source_path, dst=snap_path, read_only=True)
+    snap_info = subvol_info(snap_path)
+    nested_path = path / "nested"
+    nested_path.mkdir()
+    nested_snap_path = nested_path / "nested-snapshot"
+    create_snap(src=source_path, dst=nested_snap_path, read_only=True)
+
+    with SnapshotDir.create(path) as snapshot_dir:
+        with Source.create(source_path) as source:
+            assert snapshot_dir.get_snapshots(source) == {snap_info.uuid: snap_info}
+
+
+def test_ignore_subvolumes(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "snapshots"
+    path.mkdir()
+    source_path = btrfs_mountpoint / "source"
+    create_subvol(source_path)
+    snap_path = path / "snapshot"
+    create_snap(src=source_path, dst=snap_path, read_only=True)
+    snap_info = subvol_info(snap_path)
+    other_subvol_path = path / "other-subvol"
+    create_subvol(other_subvol_path)
+
+    with SnapshotDir.create(path) as snapshot_dir:
+        with Source.create(source_path) as source:
+            assert snapshot_dir.get_snapshots(source) == {snap_info.uuid: snap_info}
+
+
+def test_create_snapshot(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "snapshots"
+    path.mkdir()
+    source_path = btrfs_mountpoint / "source"
+    create_subvol(source_path)
+    snap_path = path / "snapshot"
+    create_snap(src=source_path, dst=snap_path, read_only=True)
+    snap_info = subvol_info(snap_path)
+
+    with SnapshotDir.create(path) as snapshot_dir:
+        with Source.create(source_path) as source:
+            snapshot_dir.create_snapshot(source, "new-snapshot")
+            new_snap_info = subvol_info(path / "new-snapshot")
+
+            assert snapshot_dir.get_snapshots(source) == {
+                snap_info.uuid: snap_info,
+                new_snap_info.uuid: new_snap_info,
+            }
+
+            snapshot_dir.destroy_snapshot(new_snap_info.id)
+
+            assert not (path / "new-snapshot").exists()
+            assert snapshot_dir.get_snapshots(source) == {snap_info.uuid: snap_info}
+
+
+def test_destroy_snapshot(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "snapshots"
+    path.mkdir()
+    source_path = btrfs_mountpoint / "source"
+    create_subvol(source_path)
+    snap_path = path / "snapshot"
+    create_snap(src=source_path, dst=snap_path, read_only=True)
+    snap_info = subvol_info(snap_path)
+
+    with SnapshotDir.create(path) as snapshot_dir:
+        with Source.create(source_path) as source:
+            snapshot_dir.destroy_snapshot(snap_info.id)
+            assert snapshot_dir.get_snapshots(source) == {}
+
+
+def test_rename_snapshot(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "snapshots"
+    path.mkdir()
+    source_path = btrfs_mountpoint / "source"
+    create_subvol(source_path)
+    snap_path = path / "snapshot"
+    create_snap(src=source_path, dst=snap_path, read_only=True)
+    snap_info = subvol_info(snap_path)
+
+    with SnapshotDir.create(path) as snapshot_dir:
+        with Source.create(source_path) as source:
+            snapshot_dir.rename_snapshot(snap_info.id, "new-name")
+
+            assert snapshot_dir.get_name(snap_info.id) == "new-name"
+            assert subvol_info(path / "new-name").id == snap_info.id
+            assert snapshot_dir.get_snapshots(source) == {snap_info.uuid: snap_info}
+
+
+def test_send(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "snapshots"
+    path.mkdir()
+    source_path = btrfs_mountpoint / "source"
+    create_subvol(source_path)
+    snap_path = path / "snapshot"
+    create_snap(src=source_path, dst=snap_path, read_only=True)
+    snap_info = subvol_info(snap_path)
+
+    with TemporaryFile(buffering=0) as tempfp:
+        with SnapshotDir.create(path) as snapshot_dir:
+            snapshot_dir.send(dst=tempfp, snapshot_id=snap_info.id)
+        tempfp.seek(0, os.SEEK_SET)
+        check_call(["btrfs", "receive", "--dump"], stdin=tempfp)
+
+
+def test_send_moved_snapshot(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "snapshots"
+    path.mkdir()
+    source_path = btrfs_mountpoint / "source"
+    create_subvol(source_path)
+    snap_path = path / "snapshot"
+    create_snap(src=source_path, dst=snap_path, read_only=True)
+    snap_info = subvol_info(snap_path)
+    snap2_path = path / "snapshot2"
+    create_snap(src=source_path, dst=snap2_path, read_only=True)
+
+    with TemporaryFile(buffering=0) as tempfp:
+        with SnapshotDir.create(path) as snapshot_dir:
+            snap_path.rename(path / "snapshot3")
+            snap2_path.rename(path / "snapshot")
+            with pytest.raises(RuntimeError, match="snapshot moved or renamed"):
+                snapshot_dir.send(dst=tempfp, snapshot_id=snap_info.id)

--- a/tests/planner/source_test.py
+++ b/tests/planner/source_test.py
@@ -1,0 +1,101 @@
+# btrfs2s3 - maintains a tree of differential backups in object storage.
+#
+# Copyright (C) 2025 Steven Brudenell and other contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from btrfs2s3._internal.backups import BackupInfo
+from btrfs2s3._internal.btrfsioctl import create_snap
+from btrfs2s3._internal.btrfsioctl import create_subvol
+from btrfs2s3._internal.btrfsioctl import subvol_info
+from btrfs2s3._internal.planner import Source
+from btrfs2s3._internal.util import backup_of_snapshot
+
+
+def test_properties(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "source"
+    create_subvol(path)
+
+    with Source.create(path) as source:
+        assert source.path == path
+        assert source.info.parent_uuid is None
+        assert Path(f"/proc/self/fd/{source.fd}").readlink() == path
+
+
+def test_close(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "source"
+    create_subvol(path)
+
+    source = Source.create(path)
+    source.close()
+
+
+def test_close_as_context_manager(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "source"
+    create_subvol(path)
+
+    with Source.create(path) as source:
+        assert source.path == path
+
+
+def test_not_a_subvol(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "source"
+    path.mkdir()
+
+    with pytest.raises(ValueError, match="not a subvolume"):
+        Source.create(path)
+
+
+def test_get_new_snapshot_name(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "source"
+    create_subvol(path)
+
+    with Source.create(path) as source:
+        name = source.get_new_snapshot_name()
+
+    assert name.startswith(path.name)
+
+
+def test_get_snapshot_name(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "source"
+    create_subvol(path)
+    snapshot_path = btrfs_mountpoint / "snapshot"
+    create_snap(src=path, dst=snapshot_path, read_only=True)
+    snapshot_info = subvol_info(snapshot_path)
+
+    with Source.create(path) as source:
+        name = source.get_snapshot_name(snapshot_info)
+
+    assert name.startswith(path.name)
+
+
+def test_get_backup_key(btrfs_mountpoint: Path) -> None:
+    path = btrfs_mountpoint / "source"
+    create_subvol(path)
+    snapshot_path = btrfs_mountpoint / "snapshot"
+    create_snap(src=path, dst=snapshot_path, read_only=True)
+    snapshot_info = subvol_info(snapshot_path)
+    backup_info = backup_of_snapshot(snapshot_info)
+
+    with Source.create(path) as source:
+        key = source.get_backup_key(backup_info)
+
+    assert key.startswith(path.name)
+    assert BackupInfo.from_path(key) == backup_info


### PR DESCRIPTION
this is an alternate approach to the assessor. among other changes, it always creates new snapshots during the planning/analysis phase. this ensures the rest of the logic works with real data instead of placeholders.

this is a significant refactor, which adds risk. I did this because I made ~5 attempts to add features to the assessor logic and was never confident my changes wouldn't break stuff. the thunk-based logic is just too convoluted.

to increase confidence in this refactor, i added a planner path for all the current assessor integration tests.

the old logic will be pulled out in later commits.