### PR TITLE
build(coverage): normalize coverage paths under tox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,12 @@ filterwarnings = [
   "ignore::DeprecationWarning:botocore.crt.auth",
 ]
 
+[tool.coverage.paths]
+source = [
+  "src/btrfs2s3",
+  "*/.tox/*/lib/python*/site-packages/btrfs2s3",
+]
+
 [tool.coverage.run]
 plugins = [
   "covdefaults",


### PR DESCRIPTION
this ensures that coverage produced by tox are correctly mapped to files in the source tree. this helps my editor with a coverage overlay.

ref https://coverage.readthedocs.io/en/7.6.12/config.html#paths

ref https://github.com/tox-dev/tox/blob/19c45334a6aeec309d3b1c5482e34750dfe2ce27/tox.ini#L158