### PR TITLE
tests: remove btrfsutil from some tests

### DIFF
--- a/src/btrfs2s3/_internal/btrfsioctl.py
+++ b/src/btrfs2s3/_internal/btrfsioctl.py
@@ -42,6 +42,8 @@ from typing import runtime_checkable
 from typing import TYPE_CHECKING
 from typing import Union
 
+from typing_extensions import Self
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from ctypes import _CData
@@ -173,6 +175,48 @@ assert sizeof(SendArgs) == (72 if sizeof(POINTER(c_uint64)) == 8 else 68)  # noq
 
 
 class SubvolInfo(NamedTuple):
+    @classmethod
+    def create(
+        cls,
+        *,
+        id: int = 0,  # noqa: A002
+        name: str = "",
+        parent_id: int = 0,
+        dir_id: int = 0,
+        generation: int = 0,
+        flags: int = 0,
+        uuid: bytes = NULL_UUID,
+        parent_uuid: bytes | None = None,
+        received_uuid: bytes | None = None,
+        ctransid: int = 0,
+        otransid: int = 0,
+        stransid: int = 0,
+        rtransid: int = 0,
+        ctime: float = 0,
+        otime: float = 0,
+        stime: float = 0,
+        rtime: float = 0,
+    ) -> Self:
+        return cls(
+            id=id,
+            name=name,
+            parent_id=parent_id,
+            dir_id=dir_id,
+            generation=generation,
+            flags=flags,
+            uuid=uuid,
+            parent_uuid=parent_uuid,
+            received_uuid=received_uuid,
+            ctransid=ctransid,
+            otransid=otransid,
+            stransid=stransid,
+            rtransid=rtransid,
+            ctime=ctime,
+            otime=otime,
+            stime=stime,
+            rtime=rtime,
+        )
+
     id: int
     name: str
     parent_id: int

--- a/src/btrfs2s3/_internal/util.py
+++ b/src/btrfs2s3/_internal/util.py
@@ -18,6 +18,8 @@
 from __future__ import annotations
 
 from enum import IntFlag
+from typing import Protocol
+from typing import TypeVar
 
 from btrfsutil import SubvolumeInfo
 
@@ -66,9 +68,22 @@ def mksubvol(
     )
 
 
-def backup_of_snapshot(
-    snapshot: SubvolumeInfo, send_parent: SubvolumeInfo | None = None
-) -> BackupInfo:
+class SubvolumeLike(Protocol):
+    @property
+    def uuid(self) -> bytes: ...
+    @property
+    def parent_uuid(self) -> bytes | None: ...
+    @property
+    def ctransid(self) -> int: ...
+    @property
+    def ctime(self) -> float: ...
+
+
+_S = TypeVar("_S", bound=SubvolumeLike)
+
+
+def backup_of_snapshot(snapshot: _S, send_parent: _S | None = None) -> BackupInfo:
+    assert snapshot.parent_uuid is not None
     return BackupInfo(
         uuid=snapshot.uuid,
         parent_uuid=snapshot.parent_uuid,

--- a/tests/resolver/marker_test.py
+++ b/tests/resolver/marker_test.py
@@ -17,27 +17,22 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+from btrfs2s3._internal.btrfsioctl import SubvolInfo
 from btrfs2s3._internal.resolver import _Marker
 from btrfs2s3._internal.resolver import Flags
 from btrfs2s3._internal.resolver import Item
 from btrfs2s3._internal.resolver import KeepMeta
 from btrfs2s3._internal.resolver import Reasons
-from btrfs2s3._internal.util import mksubvol
-
-if TYPE_CHECKING:
-    from btrfsutil import SubvolumeInfo
 
 
 def test_empty() -> None:
-    marker: _Marker[SubvolumeInfo] = _Marker()
+    marker: _Marker[SubvolInfo] = _Marker()
     assert marker.get_result() == {}
 
 
 def test_keep_reason() -> None:
-    marker: _Marker[SubvolumeInfo] = _Marker()
-    snapshot = mksubvol()
+    marker: _Marker[SubvolInfo] = _Marker()
+    snapshot = SubvolInfo.create()
     with marker.with_reasons(Reasons.Preserved):
         marker.mark(snapshot)
     assert marker.get_result() == {
@@ -46,8 +41,8 @@ def test_keep_reason() -> None:
 
 
 def test_keep_reason_and_time_span() -> None:
-    marker: _Marker[SubvolumeInfo] = _Marker()
-    snapshot = mksubvol()
+    marker: _Marker[SubvolInfo] = _Marker()
+    snapshot = SubvolInfo.create()
     time_span = (0.0, 0.0)
     with marker.with_reasons(Reasons.Preserved), marker.with_time_span(time_span):
         marker.mark(snapshot)
@@ -60,8 +55,8 @@ def test_keep_reason_and_time_span() -> None:
 
 
 def test_keep_reason_flag_and_time_span() -> None:
-    marker: _Marker[SubvolumeInfo] = _Marker()
-    snapshot = mksubvol()
+    marker: _Marker[SubvolInfo] = _Marker()
+    snapshot = SubvolInfo.create()
     time_span = (0.0, 0.0)
     with marker.with_reasons(Reasons.Preserved), marker.with_time_span(time_span):
         marker.mark(snapshot, flags=Flags.New)
@@ -76,8 +71,8 @@ def test_keep_reason_flag_and_time_span() -> None:
 
 
 def test_keep_for_multiple_reasons() -> None:
-    marker: _Marker[SubvolumeInfo] = _Marker()
-    snapshot = mksubvol()
+    marker: _Marker[SubvolInfo] = _Marker()
+    snapshot = SubvolInfo.create()
     with marker.with_reasons(Reasons.Preserved):
         marker.mark(snapshot)
         with marker.with_reasons(Reasons.MostRecent):
@@ -90,8 +85,8 @@ def test_keep_for_multiple_reasons() -> None:
 
 
 def test_keep_with_reason_context() -> None:
-    marker: _Marker[SubvolumeInfo] = _Marker()
-    snapshot = mksubvol()
+    marker: _Marker[SubvolInfo] = _Marker()
+    snapshot = SubvolInfo.create()
     with marker.with_reasons(Reasons.Preserved):
         marker.mark(snapshot)
     with marker.with_reasons(Reasons.MostRecent):
@@ -104,8 +99,8 @@ def test_keep_with_reason_context() -> None:
 
 
 def test_keep_with_reason_and_flags() -> None:
-    marker: _Marker[SubvolumeInfo] = _Marker()
-    snapshot = mksubvol()
+    marker: _Marker[SubvolInfo] = _Marker()
+    snapshot = SubvolInfo.create()
     with marker.with_reasons(Reasons.Preserved):
         marker.mark(snapshot)
         marker.mark(snapshot, flags=Flags.ReplacingNewer)
@@ -118,8 +113,8 @@ def test_keep_with_reason_and_flags() -> None:
 
 
 def test_keep_with_time_span_context() -> None:
-    marker: _Marker[SubvolumeInfo] = _Marker()
-    snapshot = mksubvol()
+    marker: _Marker[SubvolInfo] = _Marker()
+    snapshot = SubvolInfo.create()
     time_span = (0.0, 0.0)
     with marker.with_reasons(Reasons.Preserved), marker.with_time_span(time_span):
         marker.mark(snapshot)


### PR DESCRIPTION
this prepares for the upcoming removal of btrfsutil. I should have removed btrfsutil from the resolver tests in the generic resolver change.

the upcoming update2 tests will be created by copying the update tests, and btrfsutil will be removed shortly after, so we want to remove btrfsutil from these tests now to keep the changes as clean as possible.