### PR TITLE
refactor(cvar): only use TZINFO cvar, not local

### DIFF
--- a/src/btrfs2s3/_internal/commands/update2.py
+++ b/src/btrfs2s3/_internal/commands/update2.py
@@ -86,9 +86,7 @@ def _time_span_key(time_span: TS) -> tuple[float, float]:
 
 
 def _describe_time_spans(time_spans: Iterable[TS]) -> Text:
-    return describe_time_span(
-        sorted(time_spans, key=_time_span_key)[0], TZINFO.get(), bounds="[]"
-    )
+    return describe_time_span(sorted(time_spans, key=_time_span_key)[0], bounds="[]")
 
 
 def _describe_preserve(keep_meta: KeepMeta) -> Text:
@@ -386,10 +384,7 @@ class _Updater:
             snapshot_dir = self._get_snapshot_dir(Path(source_cfg["snapshots"]))
             for upload_to_remote in source_cfg["upload_to_remotes"]:
                 remote = self._get_remote(upload_to_remote["id"])
-                policy = Policy(
-                    tzinfo=self._tzinfo,
-                    params=Params.parse(upload_to_remote["preserve"]),
-                )
+                policy = Policy(params=Params.parse(upload_to_remote["preserve"]))
                 create_pipe = partial(
                     filter_pipe, upload_to_remote.get("pipe_through", [])
                 )

--- a/src/btrfs2s3/_internal/planner.py
+++ b/src/btrfs2s3/_internal/planner.py
@@ -106,7 +106,7 @@ class Source:
         return f"{self.path.name}.{ctime_str}.{info.ctransid}"
 
     def get_backup_key(self, info: BackupInfo) -> str:
-        suffixes = info.get_path_suffixes(tzinfo=TZINFO.get())
+        suffixes = info.get_path_suffixes()
         return f"{self.path.name}{''.join(suffixes)}"
 
     def close(self) -> None:

--- a/src/btrfs2s3/_internal/time_span_describer.py
+++ b/src/btrfs2s3/_internal/time_span_describer.py
@@ -22,8 +22,9 @@ import arrow
 from rich.highlighter import ISO8601Highlighter
 from rich.text import Text
 
+from btrfs2s3._internal.cvar import TZINFO
+
 if TYPE_CHECKING:
-    from datetime import tzinfo
     from typing import Literal
 
     from typing_extensions import TypeAlias
@@ -35,13 +36,11 @@ if TYPE_CHECKING:
 _iso8601_highlight = ISO8601Highlighter()
 
 
-def describe_time_span(
-    time_span: TS, tzinfo: tzinfo, *, bounds: _Bounds = "[)"
-) -> Text:
+def describe_time_span(time_span: TS, *, bounds: _Bounds = "[)") -> Text:
     """Returns a highlighted summary of a time span in context of preservation."""
     a_timestamp, b_timestamp = time_span
-    a = arrow.get(a_timestamp, tzinfo=tzinfo)
-    b = arrow.get(b_timestamp, tzinfo=tzinfo)
+    a = arrow.get(a_timestamp, tzinfo=TZINFO.get())
+    b = arrow.get(b_timestamp, tzinfo=TZINFO.get())
     if (a, b) == a.span("year", bounds=bounds):
         return Text.from_markup(f"[iso8601.date]{a.year:04d}[/] yearly")
     if (a, b) == a.span("quarter", bounds=bounds):

--- a/tests/backups/path_test.py
+++ b/tests/backups/path_test.py
@@ -40,12 +40,12 @@ def test_get_path_suffixes_with_real_timezone() -> None:
         uuid=UUID("3fd11d8e-8110-4cd0-b85c-bae3dda86a3d").bytes,
         parent_uuid=UUID("9d9d3bcb-4b62-46a3-b6e2-678eeb24f54e").bytes,
         ctransid=12345,
-        ctime=arrow.get("2006-01-01", tzinfo="US/Pacific").timestamp(),
+        ctime=arrow.get("2006-01-01").timestamp(),
         send_parent_uuid=UUID("3ae01eae-d50d-4187-b67f-cef0ef973e1f").bytes,
     )
-    got = info.get_path_suffixes(tzinfo="US/Pacific")
+    got = info.get_path_suffixes()
     expected = [
-        ".ctim2006-01-01T00:00:00-08:00",
+        ".ctim2006-01-01T00:00:00+00:00",
         ".ctid12345",
         ".uuid3fd11d8e-8110-4cd0-b85c-bae3dda86a3d",
         ".sndp3ae01eae-d50d-4187-b67f-cef0ef973e1f",

--- a/tests/preservation/policy_test.py
+++ b/tests/preservation/policy_test.py
@@ -26,6 +26,8 @@ import arrow
 import pytest
 
 from btrfs2s3._internal.arrowutil import convert_span
+from btrfs2s3._internal.cvar import TZINFO
+from btrfs2s3._internal.cvar import use_tzinfo
 from btrfs2s3._internal.preservation import Params
 from btrfs2s3._internal.preservation import Policy
 from btrfs2s3._internal.preservation import Timeframe
@@ -88,9 +90,11 @@ def test_alternate_now() -> None:
 
 
 def test_alternate_timezone() -> None:
-    tzinfo = ZoneInfo("America/Los_Angeles")
-    policy = Policy(params=Params(years=1), tzinfo=tzinfo)
-    time_span = convert_span(arrow.get(tzinfo=tzinfo).span("year", bounds="[]"))
+    with use_tzinfo(ZoneInfo("America/Los_Angeles")):
+        policy = Policy(params=Params(years=1))
+        time_span = convert_span(
+            arrow.get(tzinfo=TZINFO.get()).span("year", bounds="[]")
+        )
 
-    assert time_span in policy.iter_time_spans(time.time())
-    assert policy.should_preserve_for_time_span(time_span)
+        assert time_span in policy.iter_time_spans(time.time())
+        assert policy.should_preserve_for_time_span(time_span)

--- a/tests/time_span_describer/describe_time_span_test.py
+++ b/tests/time_span_describer/describe_time_span_test.py
@@ -23,6 +23,8 @@ import arrow
 import pytest
 from rich.text import Span
 
+from btrfs2s3._internal.cvar import TZINFO
+from btrfs2s3._internal.cvar import use_tzinfo
 from btrfs2s3._internal.time_span_describer import describe_time_span
 
 
@@ -82,10 +84,10 @@ from btrfs2s3._internal.time_span_describer import describe_time_span
 def test_describe_time_span(
     a_str: str, b_str: str, expected_plain: str, expected_spans: set[Span], tzname: str
 ) -> None:
-    tzinfo = ZoneInfo(tzname)
-    a = arrow.get(a_str, tzinfo=tzinfo)
-    b = arrow.get(b_str, tzinfo=tzinfo)
-    got = describe_time_span((a.timestamp(), b.timestamp()), tzinfo, bounds="[]")
+    with use_tzinfo(ZoneInfo(tzname)):
+        a = arrow.get(a_str, tzinfo=TZINFO.get())
+        b = arrow.get(b_str, tzinfo=TZINFO.get())
+        got = describe_time_span((a.timestamp(), b.timestamp()), bounds="[]")
     assert got.plain == expected_plain
     # The rich-provided highlighter returns loads of spans like iso8601.year
     # which aren't used by our theme. Testing all spans is overfitting. Just


### PR DESCRIPTION
as mentioned in the docs, we require an explicit app-wide timezone configuration. we should always use this TZINFO global context variable, not local arguments