### PR TITLE
build(mypy): add src and tests to mypy_path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ extras = [ "test" ]
 commands = [ [ "pytest", { replace = "posargs", default = [  ], extend = true } ] ]
 
 [tool.mypy]
+mypy_path = "src:tests"
 strict = true
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
this seems correct enough. the pre-commit config hasn't needed this because pre-commit passes all file names and mypy automatically figures out paths from there. however mypy's defaults don't seem to help for pylsp's case which needs to resolve the right paths given just one file.