### PR TITLE
ci(yaml): use yamllint --strict

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: publish
 permissions:
   contents: read
 
-on:
+"on":
   push:
     tags:
     - v*

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,7 @@ name: tests
 permissions:
   contents: read
 
-on:
+"on":
   pull_request:
   push:
     branches: [master]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
   rev: v1.37.1
   hooks:
   - id: yamllint
+    args: [--strict]
 - repo: https://github.com/executablebooks/mdformat
   rev: 0.7.22
   hooks:


### PR DESCRIPTION
previously yamllint was actually issuing warnings but silently ignoring them.

per https://github.com/adrienverge/yamllint/issues/666:

apparently YAML 1.0 (the implicit default version) treats "on" as a boolean, so actually all github actions definitions are potentially invalid. we can declare a "%YAML 1.2" directive, but this breaks yamlfmt per https://github.com/google/yamlfmt/issues/215, which uses an implicit default of version 1.2, yet doesn't support directives to declare an explicit version.