### PR TITLE
ci(mdformat): restore mdformat pyproject config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,3 +165,6 @@ tag_format = "v$version"
 version_scheme = "semver2"
 version_provider = "scm"
 update_changelog_on_bump = true
+
+[tool.mdformat]
+wrap = 88 # matches ruff


### PR DESCRIPTION
I somehow missed this in the .mdformat.yaml -> pyproject.toml migration